### PR TITLE
refactor(home): unify hover affordance between picks and latest

### DIFF
--- a/src/components/home/LatestWriting.astro
+++ b/src/components/home/LatestWriting.astro
@@ -49,6 +49,9 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
               <time class="latest__date tabular" datetime={date.toISOString()}>
                 {dateFormat.format(date)}
               </time>
+              <span class="latest__pointer" aria-hidden="true">
+                →
+              </span>
               <span class="latest__title">{post.data.title}</span>
               <span class="latest__meta tabular">
                 <span class="latest__category">{post.data.category}</span>
@@ -120,8 +123,8 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
 
   .latest__link {
     display: grid;
-    grid-template-columns: 7.5rem 1fr auto;
-    grid-template-areas: 'date title meta';
+    grid-template-columns: 7.5rem auto 1fr auto;
+    grid-template-areas: 'date pointer title meta';
     column-gap: var(--space-md);
     align-items: baseline;
     padding: 0.7rem 0;
@@ -145,12 +148,28 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
     color: var(--accent-ink);
   }
 
+  .latest__link:hover .latest__pointer,
+  .latest__link:focus-visible .latest__pointer {
+    transform: translateX(0.25rem);
+    color: var(--accent);
+  }
+
   .latest__date {
     grid-area: date;
     font-family: var(--font-mono);
     font-size: var(--text-meta);
     color: var(--ink-muted);
     letter-spacing: 0.005em;
+  }
+
+  .latest__pointer {
+    grid-area: pointer;
+    color: var(--ink-muted);
+    font-family: var(--font-mono);
+    transform: translateX(0);
+    transition:
+      transform var(--duration-fast) var(--ease-out-quart),
+      color var(--duration-fast) var(--ease-out-quart);
   }
 
   .latest__title {
@@ -187,10 +206,10 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
 
   @media (max-width: 720px) {
     .latest__link {
-      grid-template-columns: 1fr auto;
+      grid-template-columns: auto 1fr auto;
       grid-template-areas:
-        'date meta'
-        'title title';
+        'date date meta'
+        'pointer title title';
       column-gap: var(--space-sm);
       row-gap: 0.2rem;
       padding: 0.85rem 0;


### PR DESCRIPTION
## What

Adds the `→` pointer affordance and `--accent-ink` title hover to the Recent Writing rows so the two homepage lists share one hover grammar.

Curated picks already had: animated `→` pointer translating right, title color shifting to `--accent-ink`, and border-color shift on hover/focus-visible. Recent Writing only had the border-color shift. Two similar lists, two different "this is clickable" languages.

After this change both lists use the same affordance vocabulary; visual hierarchy holds through typography (picks keep their 600 display weight + mono framing kicker, latest keeps its 500 weight + date stamp). The unification is in *hover language*, not in surface treatment.

## Why

H4 from the 2026-06-17 critique: consistency between neighboring lists. Returning readers learn one affordance and shouldn't stumble on the other — directly serving PRODUCT.md principle #1 (reading depth is the north star) and the impeccable polish bar on interaction-state consistency.

## How

`src/components/home/LatestWriting.astro` only:

- Added `<span class="latest__pointer" aria-hidden="true">→</span>` between date and title.
- Grid template grows from `7.5rem 1fr auto` to `7.5rem auto 1fr auto`, areas `'date pointer title meta'` — same shape as picks' `'framing pointer title meta'`.
- Pointer styles reuse the picks tokens: `transform var(--duration-fast) var(--ease-out-quart)` + `color` transitions, `translateX(0.25rem)` and `var(--accent)` on hover/focus-visible.
- Mobile grid (`max-width: 720px`) rearranges to a 3-col `auto 1fr auto` with areas `'date date meta' / 'pointer title title'` — pointer rides the title row, matching picks' mobile pattern.
- Existing border-color hover is preserved (it's a good additional cue).

Reduced motion is already covered by the global `prefers-reduced-motion: reduce` rule in `src/styles/global.css` (universal `transition-duration: 0.01ms !important`); no per-component override needed.

## Test plan

- [x] `bun run build` clean (25 pages, no warnings)
- [x] `bun run format` + `bun run format:check` clean
- [x] Verified in both themes at 1440 via puppeteer with CDP-forced `:hover`:
  - `.claude-visual/affordances-light-picks.png`
  - `.claude-visual/affordances-light-latest.png`
  - `.claude-visual/affordances-dark-picks.png`
  - `.claude-visual/affordances-dark-latest.png`
  All four show identical hover grammar (translated `→`, accent-ink title, border lift).
- [x] WCAG AA: `--accent-ink` already meets contrast on both themes (existing token, already used by picks and links globally).
- [x] Mobile `@media (max-width: 720px)` layout still rearranges correctly with the new column added.
- [ ] Manual hover check at desktop + a 360px viewport.

Closes esttorhe_github_io-dep.