### PR TITLE
refactor(theme): drop "auto" from toggle cycle

### DIFF
--- a/src/components/site/ThemeToggle.astro
+++ b/src/components/site/ThemeToggle.astro
@@ -1,13 +1,13 @@
 ---
-// ABOUTME: Light/dark theme toggle that respects system preference but persists user choice.
-// ABOUTME: The inline script in BaseLayout sets data-theme before paint; this button cycles it.
+// ABOUTME: Binary light/dark theme toggle. System preference is the unset default.
+// ABOUTME: The inline script in BaseLayout sets data-theme before paint; this button flips it.
 ---
 
 <button
   type="button"
   class="theme-toggle"
-  aria-label="Switch theme"
-  aria-live="polite"
+  aria-label="Switch to light theme"
+  aria-pressed="false"
   data-theme-toggle
 >
   <span class="theme-toggle__inner" aria-hidden="true">
@@ -42,7 +42,7 @@
       <path d="M20.5 14.6A8.5 8.5 0 1 1 9.4 3.5a7 7 0 0 0 11.1 11.1Z"></path>
     </svg>
   </span>
-  <span class="sr-only" data-theme-label>Theme: auto</span>
+  <span class="sr-only" data-theme-label>Theme: light</span>
 </button>
 
 <style>
@@ -125,24 +125,33 @@
 </style>
 
 <script>
-  function applyClassesFromTheme() {
+  function effectiveTheme(): 'light' | 'dark' {
     const root = document.documentElement;
     const explicit = root.getAttribute('data-theme');
-    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const effective = explicit ?? (systemDark ? 'dark' : 'light');
-    root.classList.toggle('theme-dark-system', explicit === null && systemDark);
+    if (explicit === 'light' || explicit === 'dark') return explicit;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  function syncToggleState() {
+    const root = document.documentElement;
+    const explicit = root.getAttribute('data-theme');
+    const effective = effectiveTheme();
+
+    // Icon CSS already handles [data-theme='dark']; this class covers the
+    // "no explicit choice + system is dark" case so the sun shows correctly.
+    root.classList.toggle('theme-dark-system', explicit === null && effective === 'dark');
+
+    const button = document.querySelector<HTMLButtonElement>('[data-theme-toggle]');
+    if (button) {
+      const next = effective === 'dark' ? 'light' : 'dark';
+      button.setAttribute('aria-pressed', effective === 'dark' ? 'true' : 'false');
+      button.setAttribute('aria-label', `Switch to ${next} theme`);
+    }
 
     const label = document.querySelector('[data-theme-label]');
     if (label) {
-      label.textContent = `Theme: ${explicit ?? 'auto'} (currently ${effective})`;
+      label.textContent = `Theme: ${effective}`;
     }
-  }
-
-  function nextTheme(current: string | null, systemDark: boolean): string | null {
-    // Cycle: auto → light → dark → auto
-    if (current === null) return systemDark ? 'light' : 'dark';
-    if (current === 'light') return 'dark';
-    return null;
   }
 
   function wireToggle() {
@@ -150,24 +159,24 @@
     if (!button) return;
     button.addEventListener('click', () => {
       const root = document.documentElement;
-      const current = root.getAttribute('data-theme');
-      const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const next = nextTheme(current, systemDark);
-      if (next === null) {
-        root.removeAttribute('data-theme');
-        localStorage.removeItem('theme');
-      } else {
-        root.setAttribute('data-theme', next);
+      const next = effectiveTheme() === 'dark' ? 'light' : 'dark';
+      root.setAttribute('data-theme', next);
+      try {
         localStorage.setItem('theme', next);
+      } catch {
+        /* localStorage blocked — choice persists for this session only */
       }
-      applyClassesFromTheme();
+      syncToggleState();
     });
   }
 
-  applyClassesFromTheme();
+  syncToggleState();
   wireToggle();
 
-  window
-    .matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', applyClassesFromTheme);
+  // Track the system preference only while the user has made no explicit choice.
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (document.documentElement.getAttribute('data-theme') === null) {
+      syncToggleState();
+    }
+  });
 </script>


### PR DESCRIPTION
## Summary

The theme toggle used to cycle `auto → light → dark → auto`, but only light and dark had a visible glyph. Sighted users were cycling blind through an unlabelled `auto` state — the gimmicky failure mode `PRODUCT.md` calls out (`Dark / light parity. The theme toggle is real product surface, not a gimmick`).

This change ships a **binary** `light ↔ dark` toggle. System preference remains the unset default — when the user has made no explicit choice, `<html>` has no `data-theme` attribute and CSS falls back to the system via `prefers-color-scheme`. Once the user clicks, we set and persist an explicit `data-theme`.

### Why binary, not "add an auto glyph"

Three discrete icons (sun / moon / half-disk or "A") add cognitive load for a control whose purpose is binary in 99% of cases — pick the theme. The system already drives the unset default, so the user only needs to pick once if they disagree. Removing the auto step makes the action predictable from the icon alone.

### What changed

- `nextTheme` is gone. Click handler: `effectiveTheme() === 'dark' ? 'light' : 'dark'`. No null branch.
- The button uses `aria-pressed` (pressed = dark active) and the `aria-label` updates to `Switch to {next} theme` so assistive tech announces the action that's about to happen, not the state we just left.
- The `sr-only` label reads `Theme: light` or `Theme: dark` — never `auto`.
- The inline `<script is:inline>` in `BaseLayout.astro` already only writes `data-theme` for explicit `light` / `dark` values, so no FOUC change. Pre-paint flow is untouched.
- The `theme-dark-system` class still toggles when the user has no explicit choice and the system is dark — that's what lights the sun icon on first paint under a dark system preference.

### Verification

Puppeteer at 1440 width (`.claude-visual/toggle-{1,2,3}.png`), system = light:

1. **Initial:** `data-theme=null`, `aria-pressed=false`, moon icon visible, `sr-only` = `Theme: light`.
2. **After click 1:** `data-theme=dark`, `aria-pressed=true`, sun icon visible, `sr-only` = `Theme: dark`.
3. **After click 2:** `data-theme=light`, `aria-pressed=false`, moon icon visible — binary flip confirmed.

Re-run with `prefers-color-scheme: dark` emulated: initial state remains `data-theme=null` but `theme-dark-system` class lights the sun and `sr-only` reads `Theme: dark`. No invisible auto state remains anywhere in the cycle.

## Test plan

- [x] `bun run build` clean (3.49s, 25 pages)
- [x] `bun run format:check` clean
- [x] Puppeteer verifies binary flip and aria state at 1440 with system=light
- [x] Puppeteer verifies sun shows under system=dark with no explicit choice
- [x] Inline `BaseLayout` script unchanged → no FOUC regression
- [x] Keyboard focus / `:focus-visible` ring inherits from the existing button base — no regression

Closes esttorhe_github_io-tlw.