### PR TITLE
Homepage polish: seven minor sweeps from the 2026-06-17 critique

### DIFF
--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -4,7 +4,9 @@
 ---
 
 <section class="hero reveal" aria-labelledby="hero-name">
-  <p class="hero__hello" aria-hidden="true">Hi —</p>
+  <p class="hero__hello" aria-label="Hi.">
+    <span aria-hidden="true">Hi —</span>
+  </p>
   <h1 id="hero-name" class="hero__name">
     <span class="hero__name-text">Esteban Torres</span><span
       class="hero__name-mark"

--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -14,8 +14,11 @@
     >
   </h1>
   <p class="hero__role">
-    Engineering Manager. Was an iOS engineer for a decade <span class="hero__separator">·</span> now leading
-    people at <a href="https://zenjob.com" rel="noopener noreferrer">Zenjob</a>, Berlin.
+    Engineering Manager. Was an iOS engineer for a decade <span
+      class="hero__separator"
+      aria-hidden="true">—</span
+    > now leading people at <a href="https://zenjob.com" rel="noopener noreferrer">Zenjob</a>,
+    Berlin.
   </p>
   <p class="hero__lede">
     I write about engineering, management, and the messy place between them. Mostly notes to myself

--- a/src/components/home/LatestWriting.astro
+++ b/src/components/home/LatestWriting.astro
@@ -6,9 +6,11 @@ import type { CollectionEntry } from 'astro:content';
 
 interface Props {
   posts: CollectionEntry<'blog'>[];
+  /** Total post count across the archive. Defaults to `posts.length` for back-compat. */
+  totalCount?: number;
 }
 
-const { posts } = Astro.props;
+const { posts, totalCount = posts.length } = Astro.props;
 
 function postHref(post: CollectionEntry<'blog'>) {
   const date = new Date(post.data.date);
@@ -34,7 +36,7 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
   <header class="latest__header">
     <h2 id="latest-heading" class="latest__title">Recent writing</h2>
     <a class="latest__archive" href="/blog/">
-      <span>Everything ({posts.length > 9 ? '23' : posts.length})</span>
+      <span>Everything ({totalCount})</span>
       <span aria-hidden="true">→</span>
     </a>
   </header>

--- a/src/components/home/LatestWriting.astro
+++ b/src/components/home/LatestWriting.astro
@@ -36,7 +36,7 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
   <header class="latest__header">
     <h2 id="latest-heading" class="latest__title">Recent writing</h2>
     <a class="latest__archive" href="/blog/">
-      <span>Everything ({totalCount})</span>
+      <span>All {totalCount} posts</span>
       <span aria-hidden="true">→</span>
     </a>
   </header>

--- a/src/components/site/Header.astro
+++ b/src/components/site/Header.astro
@@ -85,6 +85,13 @@ const nav = [
     border-radius: 50%;
     background: var(--accent);
     transform: translateY(-0.05em);
+    transition: transform var(--duration-fast) var(--ease-out-quart);
+  }
+
+  /* On the page that the site-mark points at, lift the accent dot slightly
+     so the "you are here" signal matches `.site-nav a.is-current`. */
+  .site-mark[data-current='true'] .site-mark__dot {
+    transform: translateY(-0.05em) scale(1.35);
   }
 
   .site-nav ul {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,5 +40,5 @@ const updated = 'June 2026';
 <BaseLayout current="home">
   <Hero />
   <CuratedPicks now={now} updated={updated} picks={picks} />
-  <LatestWriting posts={latest} />
+  <LatestWriting posts={latest} totalCount={allPosts.length} />
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,9 +23,9 @@
     --rule-strong: oklch(0.78 0.012 65);
     --ink: oklch(0.2 0.005 65);
     --ink-muted: oklch(0.42 0.012 65);
-    --accent: oklch(0.55 0.16 50);
-    --accent-soft: oklch(0.94 0.05 70);
-    --accent-ink: oklch(0.42 0.18 45);
+    --accent: oklch(0.58 0.155 60);
+    --accent-soft: oklch(0.94 0.05 60);
+    --accent-ink: oklch(0.45 0.17 60);
 
     /* Type families */
     --font-display:
@@ -88,9 +88,9 @@
     --rule-strong: oklch(0.4 0.012 65);
     --ink: oklch(0.94 0.008 65);
     --ink-muted: oklch(0.68 0.012 65);
-    --accent: oklch(0.82 0.155 65);
-    --accent-soft: oklch(0.32 0.07 65);
-    --accent-ink: oklch(0.86 0.16 65);
+    --accent: oklch(0.82 0.155 60);
+    --accent-soft: oklch(0.32 0.07 60);
+    --accent-ink: oklch(0.86 0.16 60);
   }
 
   /* Auto-follow system preference when user hasn't picked. */
@@ -102,9 +102,9 @@
       --rule-strong: oklch(0.4 0.012 65);
       --ink: oklch(0.94 0.008 65);
       --ink-muted: oklch(0.68 0.012 65);
-      --accent: oklch(0.82 0.155 65);
-      --accent-soft: oklch(0.32 0.07 65);
-      --accent-ink: oklch(0.86 0.16 65);
+      --accent: oklch(0.82 0.155 60);
+      --accent-soft: oklch(0.32 0.07 60);
+      --accent-ink: oklch(0.86 0.16 60);
       color-scheme: dark;
     }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -214,6 +214,18 @@
     font-size: 0.92em;
   }
 
+  /* Form controls inherit the document's font stack instead of the
+     UA-default sans (which leaks ui-sans-serif / Apple Color Emoji
+     into computed styles). `font: inherit` resets family, size, and
+     line-height together. */
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+    color: inherit;
+  }
+
   pre {
     overflow-x: auto;
     padding: var(--space-md);


### PR DESCRIPTION
## Summary

Seven small cleanups from the 2026-06-17 homepage critique. None individually critical; together they sand the page. One commit per cleanup so a future rebase against the other five homepage PRs can drop / reorder pieces cleanly.

Closes esttorhe_github_io-tdv

## Cleanups

- [x] **Hardcoded '23'** — `LatestWriting` now takes an optional `totalCount` prop (defaults to `posts.length`); `index.astro` passes `allPosts.length`. The fallback `'23'` literal is gone.
- [x] **"Everything (23) →" copy** — rephrased to `All 23 posts →`. Single readable phrase, no parenthetical noun-count.
- [x] **"Hi —" greeting aria-hidden** — replaced `aria-hidden="true"` on the hero greeting with `aria-label="Hi."` on the `<p>` and an inner `aria-hidden` span for the visual em-dash. SR users now get a clean "Hi." instead of nothing.
- [x] **Dead `data-current` attribute** — site-mark already received `data-current={current === 'home'}` but no CSS targeted it. Added a subtle accent-dot scale-up so home gets a "you are here" cue consistent with `.site-nav a.is-current`.
- [x] **Accent hue mismatch** — light theme `--accent` was hue 50, dark was hue 65; `--accent-soft` was 70/65; `--accent-ink` was 45/65. Locked all three to hue 60 (the honey/amber anchor declared at the top of the file) in both modes. Lightness and chroma still vary per mode for contrast.
- [x] **UA-default font leak** — added `button, input, select, textarea { font: inherit; color: inherit }` in the base layer. Theme-toggle button now picks up Bricolage Grotesque instead of the UA `ui-sans-serif, system-ui, …` stack.
- [x] **Dot-separator monotone** — varied the hero role's `·` to an em-dash (`—`). The other three uses (picks meta, latest meta, footer socials) stay `·` deliberately.

## Verification

- `bun run build` clean, 25 pages.
- `bun run format:check` clean.
- Puppeteer pass at 1440×900 in both themes confirms:
  - Archive link reads `All 23 posts →` (dynamic, not hardcoded).
  - Hero greeting has `aria-label="Hi."` and no `aria-hidden`.
  - Hero separator is `—`.
  - Site-mark `data-current="true"` on `/`, with the dot transform scaling to 1.35×.
  - Accent tokens in both themes share hue 60.
  - Theme-toggle font resolves to Bricolage Grotesque.
- Contrast (canvas-resolved, AA threshold 4.5:1 for normal text):
  - Light: body 18.05:1, accent-ink on bg 7.78:1, accent on bg 4.48:1 (decorative only — used for the hero name period and a hover arrow, not text).
  - Dark: body 16.64:1, accent-ink on bg 11.36:1, accent on bg 10.52:1.
- Screenshots at `.claude-visual/polish-{light,dark}.png`.

## Merge note

**This PR is expected to rebase against the other five homepage PRs.** Esteban's planned merge order is delight → CV → affordances → toggle → spacing → this one. Touches `LatestWriting.astro`, `Hero.astro`, `Header.astro`, `global.css`, `index.astro` — conflicts likely; merge me last.

## Test plan

- [ ] Manually toggle between light and dark; confirm the accent reads as the same colour in both modes (no hue shift).
- [ ] Tab through the page; site-mark is the first focusable, hero greeting is reachable / announced.
- [ ] On `/`, the site-mark accent dot reads slightly larger than on other pages (active-page cue).
- [ ] Theme toggle button text rendering uses Bricolage, not the OS sans default.
- [ ] Hero role line reads `... a decade — now leading people at Zenjob, Berlin.` with an em-dash, not a middot.