### PR TITLE
feat(home): surface CV in the top nav

### DIFF
--- a/src/components/site/Header.astro
+++ b/src/components/site/Header.astro
@@ -1,12 +1,12 @@
 ---
 // ABOUTME: Site header — wordmark + restrained nav + theme toggle.
-// ABOUTME: No mobile-hamburger; the nav stays one row because it has three items.
+// ABOUTME: Nav surfaces Writing / Talks / CV / About so all three audiences land in one click.
 
 import ThemeToggle from './ThemeToggle.astro';
 
 interface Props {
   /** When set, that nav item gets aria-current="page". */
-  current?: 'home' | 'writing' | 'talks' | 'about';
+  current?: 'home' | 'writing' | 'talks' | 'cv' | 'about';
 }
 
 const { current } = Astro.props;
@@ -14,6 +14,7 @@ const { current } = Astro.props;
 const nav = [
   { id: 'writing', label: 'Writing', href: '/blog/' },
   { id: 'talks', label: 'Talks', href: '/talks/' },
+  { id: 'cv', label: 'CV', href: '/cv/' },
   { id: 'about', label: 'About', href: '/about/' },
 ] as const;
 ---

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,7 +12,7 @@ interface Props {
   /** When true, suppresses the site-name suffix in the document title. */
   bareTitle?: boolean;
   /** Which nav item is current, if any. */
-  current?: 'home' | 'writing' | 'talks' | 'about';
+  current?: 'home' | 'writing' | 'talks' | 'cv' | 'about';
 }
 
 const {

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,0 +1,22 @@
+---
+// ABOUTME: Placeholder CV index — keeps the new top-nav link out of 404 land while the real page is built.
+// ABOUTME: A follow-up task fleshes this out into the hiring-manager surface PRODUCT.md asks for.
+
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout title="CV" current="cv">
+  <h1>CV</h1>
+  <p class="cv-placeholder">
+    Coming soon. The hiring-manager-friendly version of this page is being built. In the meantime,
+    the <a href="/about/">about page</a> covers the basics — current role, location, and what I do.
+  </p>
+</BaseLayout>
+
+<style>
+  .cv-placeholder {
+    margin-top: var(--space-md);
+    color: var(--ink-muted);
+    max-width: var(--measure);
+  }
+</style>


### PR DESCRIPTION
## What

Adds a `CV` item to the primary site nav between `Talks` and `About`, and a placeholder `/cv/` page so the link doesn't 404 in dev. No hero, footer, or section-spacing changes — header + base layout prop union only.

- `src/components/site/Header.astro` — `CV` slotted into the nav array; `current` union widened to include `'cv'`.
- `src/layouts/BaseLayout.astro` — matching widen of the `current` prop union so pages can mark themselves current.
- `src/pages/cv.astro` — placeholder page (h1 + one paragraph pointing at `/about/`), wears `current="cv"`. Stub for a follow-up that builds out the real hiring-manager surface.

## Why

`PRODUCT.md` Design Principle #3 — "Three audiences, one front door." The home page has to work in five seconds for hiring managers, engineers/EMs, and conference organizers. Today the header surfaces Writing / Talks / About; the hiring-manager (Hannah) path requires guessing CV lives inside About, which is a five-second-test failure.

Of the three valid shapes the issue offered (a) CV in nav, (b) inline mono row under the hero lede, (c) hero copy rewrite — I picked **(a)**:

- it matches the existing nav grammar (mono, restrained, ordered by audience weight) rather than introducing a new CTA surface.
- it costs one nav slot, not a hero rewrite or another hero row — aligning with the plainspoken, restrained register.
- it keeps the hero's role+lede pairing fully owned by agent #1's typographic work; this change does not touch the hero.

Trade-off: 4 nav items instead of 3. Verified the header still reflows below 540px without overlap (Writing / Talks / CV / About fits one row at 375px; screenshots in `.claude-visual/`).

## Test plan

- [x] `bun run build` passes; `/cv/index.html` is in `dist/`.
- [x] `bun run format:check` clean.
- [x] Visually verified light + dark at 1440px and 375px via puppeteer screenshots in `.claude-visual/hero-cv-*.png`.
- [x] `/` returns 200 in preview; `/cv/` returns 200 in preview.
- [x] CV link visible at first paint in both themes at both widths.
- [x] At 375px the nav reflows below the wordmark (existing `@media (max-width: 540px)` rule) without wrap or overflow.
- [x] `aria-current="page"` lands on CV when the placeholder is the current route.
- [ ] Real CV content — follow-up.

Closes esttorhe_github_io-wjz.