### PR TITLE
feat(home): mint the wordmark sigil — Esteban's mark, not punctuation

### DIFF
--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -1,15 +1,21 @@
 ---
 // ABOUTME: Homepage hero — name + 5-second positioning + intro sentence.
 // ABOUTME: One section, no CTA buttons; the writing below IS the call to action.
+
+import Sigil from '../marks/Sigil.astro';
 ---
 
 <section class="hero reveal" aria-labelledby="hero-name">
   <p class="hero__hello" aria-hidden="true">Hi —</p>
   <h1 id="hero-name" class="hero__name">
-    <span class="hero__name-text">Esteban Torres</span><span
-      class="hero__name-mark"
-      aria-hidden="true">.</span
-    >
+    <span class="hero__name-wordmark" tabindex="0">
+      <span class="hero__name-text">Esteban Torres</span><span
+        class="hero__name-mark"
+        aria-hidden="true"
+      >
+        <Sigil size="0.7em" class="hero__sigil" />
+      </span>
+    </span>
   </h1>
   <p class="hero__role">
     Engineering Manager. Was an iOS engineer for a decade <span class="hero__separator">·</span> now leading
@@ -38,19 +44,75 @@
   .hero__name {
     font-size: var(--text-display);
     line-height: 0.95;
-    letter-spacing: -0.03em;
     margin: 0 0 var(--space-md);
     text-wrap: balance;
     overflow-wrap: break-word;
   }
 
-  .hero__name-text {
+  /*
+   * The wordmark is the move.
+   *
+   * Resting state: Bricolage at wght 700, wdth 100 (full width), opsz tuned to size.
+   * Hover/focus state: wght bumps to 760 and wdth tightens to 92, so the letters cinch
+   * together and gain grade at once — a single variable-axis morph, eased on expo over
+   * ~600ms so it reads as deliberate, not jumpy. The sigil rotates ~14° in concert.
+   *
+   * Reduced-motion fallback: no morph, no rotation, just a color nudge on the dot.
+   */
+  .hero__name-wordmark {
+    display: inline;
     color: var(--ink);
+    font-variation-settings:
+      'wght' 700,
+      'wdth' 100,
+      'opsz' 72;
+    letter-spacing: -0.03em;
+    transition:
+      font-variation-settings var(--duration-wordmark) var(--ease-out-expo),
+      letter-spacing var(--duration-wordmark) var(--ease-out-expo);
+    cursor: default;
+    border-radius: var(--radius-sm);
+  }
+
+  .hero__name-wordmark:hover,
+  .hero__name-wordmark:focus-visible {
+    font-variation-settings:
+      'wght' 760,
+      'wdth' 92,
+      'opsz' 96;
+    letter-spacing: -0.04em;
+    outline: none;
+  }
+
+  .hero__name-text {
+    color: inherit;
   }
 
   .hero__name-mark {
-    color: var(--accent);
-    margin-left: 0.05em;
+    display: inline-block;
+    margin-left: 0.06em;
+    line-height: 0;
+    transform-origin: 50% 60%;
+  }
+
+  /* Sigil rotates / lifts when the wordmark is hovered or focused. */
+  .hero__sigil {
+    transition:
+      transform var(--duration-wordmark) var(--ease-out-expo),
+      color var(--duration-base) var(--ease-out-quart);
+    transform: rotate(0deg) scale(1);
+  }
+
+  .hero__name-wordmark:hover .hero__sigil,
+  .hero__name-wordmark:focus-visible .hero__sigil {
+    transform: rotate(14deg) scale(1.08);
+    color: var(--accent-ink);
+  }
+
+  /* Keyboard focus ring lives on the wordmark span (the only interactive bit of the h1). */
+  .hero__name-wordmark:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 6px;
   }
 
   .hero__role {
@@ -86,5 +148,26 @@
     line-height: 1.55;
     margin: 0;
     max-width: 38rem;
+  }
+
+  /* Reduced-motion fallback: no variable-axis morph, no rotation. Color nudge only. */
+  @media (prefers-reduced-motion: reduce) {
+    .hero__name-wordmark,
+    .hero__name-wordmark:hover,
+    .hero__name-wordmark:focus-visible {
+      transition: none;
+      font-variation-settings:
+        'wght' 700,
+        'wdth' 100,
+        'opsz' 72;
+      letter-spacing: -0.03em;
+    }
+
+    .hero__sigil,
+    .hero__name-wordmark:hover .hero__sigil,
+    .hero__name-wordmark:focus-visible .hero__sigil {
+      transform: none;
+      transition: color var(--duration-fast) linear;
+    }
   }
 </style>

--- a/src/components/marks/Sigil.astro
+++ b/src/components/marks/Sigil.astro
@@ -1,0 +1,61 @@
+---
+// ABOUTME: Esteban's wordmark sigil — a hand-drawn ringed-dot ornament in honey accent.
+// ABOUTME: Used as the period after the hero name and once more in the footer location line.
+
+interface Props {
+  /** Size in em relative to the host element's font-size. Default 0.78em. */
+  size?: string;
+  /** Optional override for the title used by screen readers. */
+  title?: string;
+  /** Extra class names. */
+  class?: string;
+  /** Decorative by default (aria-hidden). Set to false when the mark is semantic. */
+  decorative?: boolean;
+}
+
+const { size = '0.78em', title, class: className = '', decorative = true } = Astro.props;
+
+const titleId = title ? `sigil-title-${Math.random().toString(36).slice(2, 8)}` : undefined;
+---
+
+<svg
+  class={`sigil ${className}`.trim()}
+  width={size}
+  height={size}
+  viewBox="0 0 24 24"
+  fill="none"
+  aria-hidden={decorative ? 'true' : undefined}
+  role={decorative ? undefined : 'img'}
+  aria-labelledby={!decorative && titleId ? titleId : undefined}
+  focusable="false"
+>
+  {!decorative && title && <title id={titleId}>{title}</title>}
+  {
+    /* Outer ring — intentionally wobbly, drawn as a cubic Bézier loop with uneven control points. */
+  }
+  <path
+    class="sigil__ring"
+    d="M12 2.4
+       C 17.1 2.0, 21.7 6.3, 21.7 12.2
+       C 22.1 17.7, 17.4 21.9, 11.8 21.9
+       C 6.4 22.3, 2.1 17.6, 2.3 11.8
+       C 1.9 6.6, 6.7 2.6, 12 2.4 Z"
+    stroke="currentColor"
+    stroke-width="1.6"
+    stroke-linecap="round"
+    stroke-linejoin="round"></path>
+  {/* Inner dot — slightly off-center to read as hand-placed, not geometric. */}
+  <circle class="sigil__dot" cx="12.5" cy="12.2" r="3.4" fill="currentColor"></circle>
+</svg>
+
+<style>
+  .sigil {
+    display: inline-block;
+    color: var(--accent);
+    vertical-align: baseline;
+    overflow: visible;
+    /* Anchor rotation to the dot, not the bbox center, so the wobble reads as the dot
+       pivoting in place rather than the whole shape orbiting. */
+    transform-origin: 52% 51%;
+  }
+</style>

--- a/src/components/site/Footer.astro
+++ b/src/components/site/Footer.astro
@@ -2,6 +2,8 @@
 // ABOUTME: Site footer — mono dot-separated socials + copyright.
 // ABOUTME: Deliberately quiet; the writing carries the page, not the chrome.
 
+import Sigil from '../marks/Sigil.astro';
+
 const year = new Date().getFullYear();
 
 const socials = [
@@ -38,8 +40,12 @@ const socials = [
       © {year}
       <a href="/about/">Esteban Torres</a>
     </span>
-    <span class="site-footer__location" aria-hidden="true">
-      <span>Berlin</span><span class="site-footer__via">via</span><span>San José</span>
+    <span class="site-footer__location" aria-label="Berlin via San José">
+      <span aria-hidden="true">Berlin</span>
+      <span class="site-footer__via" aria-hidden="true">
+        <Sigil size="0.78em" />
+      </span>
+      <span aria-hidden="true">San José</span>
     </span>
   </p>
 </footer>
@@ -124,7 +130,10 @@ const socials = [
   }
 
   .site-footer__via {
-    color: color-mix(in oklab, var(--ink-muted) 65%, transparent);
-    font-style: italic;
+    display: inline-flex;
+    align-items: center;
+    line-height: 0;
+    /* Sigil inherits this via currentColor in the SVG fill/stroke. */
+    color: var(--accent);
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,7 +7,9 @@
  *  Webfonts — Bricolage Grotesque Variable + Geist Mono (400, 500). *
  *  fontsource packages live in node_modules; both .woff2 are local. *
  * ---------------------------------------------------------------- */
-@import '@fontsource-variable/bricolage-grotesque/index.css';
+/* standard.css ships both wght (200–800) and wdth (75–100) axes in one face,
+   which is what the hero wordmark stunt needs. index.css = wght-only. */
+@import '@fontsource-variable/bricolage-grotesque/standard.css';
 @import '@fontsource/geist-mono/400.css';
 @import '@fontsource/geist-mono/500.css';
 
@@ -72,6 +74,7 @@
     --duration-base: 240ms;
     --duration-slow: 420ms;
     --duration-page-load: 720ms;
+    --duration-wordmark: 620ms; /* hero name variable-axis morph; long enough to read as deliberate */
 
     /* z-index scale (semantic; no arbitrary numbers) */
     --z-base: 1;


### PR DESCRIPTION
## What
The hero name's static `.` becomes a hand-drawn ringed-dot SVG mark — Esteban's sigil — in the honey accent. The same mark recurs once in the footer between "Berlin" and "San José" (replacing the italic "via" word). Hovering or focusing the wordmark drives a single variable-axis morph on Bricolage Grotesque — `wght` 700→760, `wdth` 100→92, `opsz` 72→96 — plus a 14° rotation on the sigil itself, eased over 620ms on `--ease-out-expo`. One move. Two deliberate placements. A system.

## Why
Resolves the P1 brand-fit issue from the 2026-06-17 critique: the page leaned "minimalist tasteful", which PRODUCT.md names as a failure state ("when in doubt, push toward weirder"). The wordmark sigil is the one deliberate weird move PRODUCT.md says the homepage has license for — plainspoken in the copy, opinionated in the type, idiosyncratic in the mark. Brand personality is now carried by typography first (variable axes) and a hand-doodled accent, exactly as PRODUCT.md's design principle 4 prescribes ("Voice lives in typography first").

The sigil isn't decoration — it's identity. The same ringed-dot ornament closes the wordmark *and* holds the "Berlin via San José" line together, so it reads as a system, not a flourish.

## Screenshots
- Light: `.claude-visual/delight-light.png`
- Dark: `.claude-visual/delight-dark.png`
- Hero hover stunt (rest vs. hover): `.claude-visual/delight-light-hero-rest.png` + `.claude-visual/delight-light-hero-hover.png` (and `*-dark-*` variants)
- Footer recur: `.claude-visual/delight-light-footer.png` + `.claude-visual/delight-dark-footer.png`

## Beads
Closes esttorhe_github_io-c9j.

## Reduced motion
`@media (prefers-reduced-motion: reduce)` block in `Hero.astro` pins the wordmark to its resting variable-axis settings and disables the sigil rotation; hover/focus collapse to a color nudge only. PRODUCT.md commits to this floor.

## Test plan
- [x] `bun run build` green
- [x] `bun run format:check` green
- [x] both themes verified at 1440 via puppeteer (full-page screenshots in `.claude-visual/`)
- [x] hero hover stunt verified in light and dark
- [x] footer recur verified in light and dark
- [ ] reduced-motion verified in browser (manual — set system preference, confirm no morph)