### PR TITLE
fix(home): swap hero role em-dash for middot to match site grammar

### DIFF
--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -22,7 +22,7 @@ import Sigil from '../marks/Sigil.astro';
   <p class="hero__role">
     Engineering Manager. Was an iOS engineer for a decade <span
       class="hero__separator"
-      aria-hidden="true">—</span
+      aria-hidden="true">·</span
     > now leading people at <a href="https://zenjob.com" rel="noopener noreferrer">Zenjob</a>,
     Berlin.
   </p>


### PR DESCRIPTION
## What

In the homepage hero role line, swap the em-dash separator between "decade" and "now leading" for `·` (U+00B7 MIDDLE DOT).

Before:

> Engineering Manager. Was an iOS engineer for a decade — now leading people at Zenjob, Berlin.

After:

> Engineering Manager. Was an iOS engineer for a decade · now leading people at Zenjob, Berlin.

The `Hi —` kicker two lines above is untouched — it earns its em-dash as a phrasal pause, not an inline separator.

## Why

Critique v2 NP2: the inline em-dash was reading as editorial-magazine voice and collided with the kicker two lines up, doubling the same glyph in the most visible 200px of the page.

Picked **option (a) — revert to `·`** for two reasons:

1. **System consistency.** The dot is the established separator across the page: `CuratedPicks` meta (`{category} · {year}`), `LatestWriting` row (`date · title · category · time`), and `Footer` socials all already use it. Hero was the odd one out.
2. **PRODUCT.md explicitly calls it out.** Line 31 names "mono-typed footers separated by dots" as part of the brand's idiosyncratic vocabulary — the dot *is* the voice, not a fallback to it.

(c) Sigil-as-ornament was tempting (most idiosyncratic, would make the brand mark do triple duty) but I declined it for this PR: the Sigil currently does two jobs (wordmark tail, footer location), and inserting it into the role copy where the eye lands second risks turning a brand element into a punctuation tic. If it's worth doing, it's worth doing deliberately in its own pass — not as a typeset-fix side effect.

## Scope

Single character swap inside the existing `<span class="hero__separator">`. No CSS changes — the existing `color: var(--ink-muted); margin: 0 0.25ch` rules already work for the dot (same pattern as `.latest__dot` and `.site-footer__sep`).

## Verification

- `bun run build` clean.
- `bun run format` clean.
- Light + dark @ 1440, mobile @ 375. Screenshots attached. Contrast checked on muted token (already AA-compliant in the design system).

### Light @ 1440
![light 1440 crop](.claude-visual/hero-typeset-light-1440-crop.png)

### Dark @ 1440
![dark 1440 crop](.claude-visual/hero-typeset-dark-1440-crop.png)

### Mobile @ 375
![mobile 375 crop](.claude-visual/hero-typeset-light-375-crop.png)

## Constraints honored

- Only touched `src/components/home/Hero.astro` — global.css, other home components, and the wordmark/Sigil hover behavior untouched.
- WCAG AA contrast preserved (no token change; muted ink already passes).
- Conventional Commits.

Closes esttorhe_github_io-80r