### PR TITLE
fix(header): replace site-mark dot with Sigil ornament

### DIFF
--- a/src/components/site/Header.astro
+++ b/src/components/site/Header.astro
@@ -3,6 +3,7 @@
 // ABOUTME: Nav surfaces Writing / Talks / CV / About so all three audiences land in one click.
 
 import ThemeToggle from './ThemeToggle.astro';
+import Sigil from '../marks/Sigil.astro';
 
 interface Props {
   /** When set, that nav item gets aria-current="page". */
@@ -27,7 +28,9 @@ const nav = [
     data-current={current === 'home'}
   >
     <span class="site-mark__name">Esteban Torres</span>
-    <span class="site-mark__dot" aria-hidden="true"></span>
+    <span class="site-mark__sigil" aria-hidden="true">
+      <Sigil size="0.7em" />
+    </span>
   </a>
 
   <nav class="site-nav" aria-label="Primary">
@@ -80,18 +83,20 @@ const nav = [
     line-height: 1;
   }
 
-  .site-mark__dot {
-    width: 0.4rem;
-    height: 0.4rem;
-    border-radius: 50%;
-    background: var(--accent);
+  .site-mark__sigil {
+    display: inline-flex;
+    align-items: center;
+    line-height: 0;
+    /* Sigil inherits this via currentColor in the SVG fill/stroke. */
+    color: var(--accent);
     transform: translateY(-0.05em);
+    transform-origin: center;
     transition: transform var(--duration-fast) var(--ease-out-quart);
   }
 
-  /* On the page that the site-mark points at, lift the accent dot slightly
+  /* On the page that the site-mark points at, lift the sigil slightly
      so the "you are here" signal matches `.site-nav a.is-current`. */
-  .site-mark[data-current='true'] .site-mark__dot {
+  .site-mark[data-current='true'] .site-mark__sigil {
     transform: translateY(-0.05em) scale(1.35);
   }
 


### PR DESCRIPTION
## Summary

- Header's `.site-mark__dot` (CSS-painted `<span>`) is swapped for an inline `<Sigil />` so the brand-ornament vocabulary stays consistent across all three deploys: hero · header · footer.
- The Sigil sits in a `.site-mark__sigil` wrapper that carries `color: var(--accent)` (the Sigil SVG uses `currentColor` for stroke + fill), so the honey/amber color matches the dot it replaced.
- Active-page indicator from #75 is preserved: on the home route `data-current='true'` scales the Sigil container to `scale(1.35)`. On non-home routes it sits at 1.0x.

## Why

A returning reader who's parsed the Sigil as the brand reads the header dot as a placeholder — the recurring-mark vocabulary lands twice cleanly (hero, footer), third time as "almost." This closes the loop. Critique v2 NP5.

## Test plan

- [x] `bun run build` clean
- [x] `bun run format` clean
- [x] Sigil renders at 0.7em (~11px non-home, ~15px on home with active scale) — verified via `getBoundingClientRect`
- [x] `data-current` attribute drives the scale: home -> matrix(1.35, ...), non-home -> matrix(1, ...) — verified via `getComputedStyle`
- [x] Color resolves to `oklch(0.58 0.155 60)` (the honey/amber accent) in both themes
- [x] Screenshots in `.claude-visual/sigil-header-{light,dark}.png` (home) and `.claude-visual/sigil-header-nonhome-{light,dark}.png` (`/blog/`)
- [x] No touch outside `src/components/site/Header.astro`

Closes esttorhe_github_io-vcs