### PR TITLE
feat(hero): auto-trigger wordmark morph on first viewport entry

### DIFF
--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -62,7 +62,12 @@ import Sigil from '../marks/Sigil.astro';
    * together and gain grade at once — a single variable-axis morph, eased on expo over
    * ~600ms so it reads as deliberate, not jumpy. The sigil rotates ~14° in concert.
    *
+   * Touch users never trigger :hover or :focus-visible, so a one-shot reveal class
+   * (`.is-revealing`) replays the same morph automatically when the hero enters the
+   * viewport — see the IntersectionObserver script at the bottom of this file.
+   *
    * Reduced-motion fallback: no morph, no rotation, just a color nudge on the dot.
+   * The script also bails entirely under reduced-motion (belt + braces).
    */
   .hero__name-wordmark {
     display: inline;
@@ -80,7 +85,8 @@ import Sigil from '../marks/Sigil.astro';
   }
 
   .hero__name-wordmark:hover,
-  .hero__name-wordmark:focus-visible {
+  .hero__name-wordmark:focus-visible,
+  .hero__name-wordmark.is-revealing {
     font-variation-settings:
       'wght' 760,
       'wdth' 92,
@@ -109,7 +115,8 @@ import Sigil from '../marks/Sigil.astro';
   }
 
   .hero__name-wordmark:hover .hero__sigil,
-  .hero__name-wordmark:focus-visible .hero__sigil {
+  .hero__name-wordmark:focus-visible .hero__sigil,
+  .hero__name-wordmark.is-revealing .hero__sigil {
     transform: rotate(14deg) scale(1.08);
     color: var(--accent-ink);
   }
@@ -159,7 +166,8 @@ import Sigil from '../marks/Sigil.astro';
   @media (prefers-reduced-motion: reduce) {
     .hero__name-wordmark,
     .hero__name-wordmark:hover,
-    .hero__name-wordmark:focus-visible {
+    .hero__name-wordmark:focus-visible,
+    .hero__name-wordmark.is-revealing {
       transition: none;
       font-variation-settings:
         'wght' 700,
@@ -170,9 +178,55 @@ import Sigil from '../marks/Sigil.astro';
 
     .hero__sigil,
     .hero__name-wordmark:hover .hero__sigil,
-    .hero__name-wordmark:focus-visible .hero__sigil {
+    .hero__name-wordmark:focus-visible .hero__sigil,
+    .hero__name-wordmark.is-revealing .hero__sigil {
       transform: none;
       transition: color var(--duration-fast) linear;
     }
   }
 </style>
+
+<script>
+  // ABOUTME: One-shot wordmark morph for touch users — replays the hover state on
+  // ABOUTME: hero enter so :hover-less devices still see the peak emotional moment.
+  (() => {
+    const wordmark = document.querySelector<HTMLElement>('.hero__name-wordmark');
+    if (!wordmark) return;
+
+    // Respect reduced-motion: do not trigger the morph at all.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    // Hold time matches --duration-wordmark (620ms) plus a small tail so the
+    // morph completes before we release the class and the wordmark eases back.
+    const HOLD_MS = 700;
+
+    const playOnce = () => {
+      wordmark.classList.add('is-revealing');
+      window.setTimeout(() => wordmark.classList.remove('is-revealing'), HOLD_MS);
+    };
+
+    // Hero is above the fold — the observer will fire on initial paint.
+    // Using IO (rather than a raw setTimeout) means the morph also replays
+    // correctly when navigating back to the homepage via the Astro view
+    // transition / bfcache.
+    if (!('IntersectionObserver' in window)) {
+      playOnce();
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      (entries, observer) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            playOnce();
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { threshold: 0.4 },
+    );
+
+    io.observe(wordmark);
+  })();
+</script>


### PR DESCRIPTION
## Summary

- Touch (iOS / Android) users never trigger `:hover` or `:focus-visible`, so they were missing the variable-axis morph + Sigil rotation that PRODUCT.md treats as the homepage's peak emotional moment.
- Adds an `IntersectionObserver` that lands `.is-revealing` on `.hero__name-wordmark` when the hero enters the viewport (fires on initial paint since the hero is above the fold), holds for 700ms — long enough for the 620ms `--duration-wordmark` morph to ease into its peak — then removes the class.
- The triggered class shares the same selector group as `:hover` and `:focus-visible`, so mouse + keyboard behaviour is preserved; this is purely additive.
- `prefers-reduced-motion` is respected at two layers: the script bails before adding the class, and the existing reduced-motion CSS block also neutralizes `.is-revealing` for belt + braces.
- Scoped entirely to `src/components/home/Hero.astro` — no global token or shared CSS touched.

## Verification

Captured with Puppeteer against `bun astro dev` (light theme):

- `.claude-visual/wordmark-auto.png` — page on load, ~250ms after the observer fires: Sigil tilted ~14°, name visibly tighter / heavier. Mid-morph computed style: `wght 756.5, wdth 92.5, opsz 94.6`.
- `.claude-visual/wordmark-reduced.png` — same page, `prefers-reduced-motion: reduce` emulated: Sigil upright, name at resting weight. Script log empty (no class change ever attempted). Computed style at rest: `wght 700, wdth 100, opsz 72`.

The morph affects type weight + Sigil rotation only (no colour), so both themes look correct.

## Test plan

- [x] `bun run build` succeeds.
- [x] `bun run format` clean.
- [x] Puppeteer headless: auto path triggers the morph, computed font-variation-settings move toward target.
- [x] Puppeteer headless with `prefers-reduced-motion: reduce`: morph never fires, wordmark stays at resting state.
- [ ] Manual check on a real iOS / Android device.
- [ ] Manual check that hover on a desktop mouse still morphs after the initial reveal.
- [ ] Manual check that keyboard `Tab` to the wordmark still triggers `:focus-visible` morph.

Closes esttorhe_github_io-9qa