### PR TITLE
feat(cv): replace stub with real /cv/ from cv.git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/cv"]
+	path = external/cv
+	url = git@github.com:esttorhe/cv.git

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,9 @@ package-lock.json
 # Static assets served verbatim
 public/
 
+# Submodules — their content is owned upstream, never formatted here.
+external/
+
 # Agent infra (kept out of source via .gitignore but included here as a belt-and-suspenders)
 .claude/
 .claude-visual/

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "tailwindcss": "^4.1.18",
       },
       "devDependencies": {
+        "marked": "^18.0.5",
         "prettier": "^3.8.4",
         "prettier-plugin-astro": "^0.14.1",
         "puppeteer": "^25.1.0",
@@ -572,6 +573,8 @@
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
+    "marked": "^18.0.5",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "puppeteer": "^25.1.0"

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,22 +1,362 @@
 ---
-// ABOUTME: Placeholder CV index — keeps the new top-nav link out of 404 land while the real page is built.
-// ABOUTME: A follow-up task fleshes this out into the hiring-manager surface PRODUCT.md asks for.
+// ABOUTME: Renders the CV from the cv.git submodule (external/cv/cv.md) at build time.
+// ABOUTME: Falls back to a polite unavailable message + social links if the submodule isn't initialised.
 
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { marked } from 'marked';
 import BaseLayout from '../layouts/BaseLayout.astro';
+
+const cvPath = fileURLToPath(new URL('../../external/cv/cv.md', import.meta.url));
+
+let rendered: string | null = null;
+let loadError: string | null = null;
+
+try {
+  const source = await readFile(cvPath, 'utf8');
+  // marked is configured for GFM. We leave HTML in the source untouched —
+  // the cv.md uses empty <h3></h3> tags as visual separators between roles.
+  marked.setOptions({ gfm: true, breaks: false });
+  rendered = await marked.parse(source);
+} catch (err) {
+  loadError = err instanceof Error ? err.message : String(err);
+}
+
+const fallbackSocials = [
+  { label: 'email', href: 'mailto:me@estebantorr.es' },
+  { label: 'github', href: 'https://github.com/esttorhe' },
+  { label: 'linkedin', href: 'https://linkedin.com/in/estebantorres' },
+  { label: 'mastodon', href: 'https://mastodon.social/@esttorhe' },
+];
 ---
 
-<BaseLayout title="CV" current="cv">
-  <h1>CV</h1>
-  <p class="cv-placeholder">
-    Coming soon. The hiring-manager-friendly version of this page is being built. In the meantime,
-    the <a href="/about/">about page</a> covers the basics — current role, location, and what I do.
-  </p>
+<BaseLayout
+  title="CV — Esteban Torres"
+  bareTitle
+  description="Engineering leadership CV — Head of Engineering, Engineering Manager, iOS/Platform roles across Zenjob, Spotify, SoundCloud, and earlier."
+  current="cv"
+>
+  {
+    rendered ? (
+      <article class="cv reveal" set:html={rendered} />
+    ) : (
+      <article class="cv cv--fallback reveal">
+        <h1>CV</h1>
+        <p>
+          The CV is temporarily unavailable — the submodule it lives in hasn't been initialised yet.
+          If you're cloning the repo, run <code>git submodule update --init --recursive</code> and
+          rebuild. Meanwhile, the quickest way to reach Esteban is below.
+        </p>
+        <ul class="cv-fallback__socials">
+          {fallbackSocials.map((item) => (
+            <li>
+              <a href={item.href}>{item.label}</a>
+            </li>
+          ))}
+        </ul>
+        {loadError && (
+          <p class="cv-fallback__diagnostic">
+            <small>Build-time note: {loadError}</small>
+          </p>
+        )}
+      </article>
+    )
+  }
 </BaseLayout>
 
 <style>
-  .cv-placeholder {
-    margin-top: var(--space-md);
+  /* ---------------------------------------------------------------- *
+   *  CV page — denser than blog prose, plainspoken hierarchy.        *
+   *  No SaaS-resume sidebar, no eyebrows, no numbered markers.       *
+   * ---------------------------------------------------------------- */
+  .cv {
+    max-width: var(--measure-wide);
+    color: var(--ink);
+    font-size: var(--text-body);
+    line-height: 1.55;
+  }
+
+  /* Name — quieter than a hero, but unambiguously the top of the page. */
+  .cv :global(h1) {
+    font-size: var(--text-h1);
+    margin-bottom: var(--space-xs);
+    letter-spacing: -0.03em;
+  }
+
+  /* Current role tagline (h2 directly after h1). */
+  .cv :global(h1 + h2) {
+    font-size: var(--text-lead);
+    font-weight: 500;
     color: var(--ink-muted);
+    letter-spacing: -0.01em;
+    margin-bottom: var(--space-md);
+  }
+
+  /* Contact block — a blockquote of links in the source markdown. */
+  .cv :global(blockquote) {
+    margin: 0 0 var(--space-lg);
+    padding: 0;
+    border: 0;
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: var(--space-md);
+    row-gap: var(--space-2xs);
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+  }
+  .cv :global(blockquote p) {
+    margin: 0;
+  }
+  .cv :global(blockquote a) {
+    color: var(--ink);
+  }
+  .cv :global(blockquote a:hover) {
+    color: var(--accent-ink);
+  }
+
+  /* Section rule between top-level sections. The source markdown uses
+     `------` between sections, which renders as <hr>. */
+  .cv :global(hr) {
+    border: 0;
+    border-top: 1px solid var(--rule);
+    margin: var(--space-lg) 0 var(--space-md);
+  }
+
+  /* Section heading — Work Experience / Projects / Education / etc. */
+  .cv :global(h3) {
+    font-size: var(--text-h3);
+    font-family: var(--font-display);
+    font-weight: 600;
+    letter-spacing: -0.015em;
+    margin: var(--space-md) 0 var(--space-sm);
+  }
+
+  /* The cv.md uses `<h3></h3>` (empty) as a visual gap between roles.
+     Don't reserve a full h3 of vertical space for them. */
+  .cv :global(h3:empty) {
+    margin: 0;
+    height: var(--space-sm);
+  }
+
+  /* Paragraphs — role descriptions. Tighter than blog prose. */
+  .cv :global(p) {
+    margin: 0 0 var(--space-sm);
+  }
+
+  /* Role line — the first paragraph after each empty separator opens
+     with **`Company`** *Title* **Dates**. That's all bold/em runs in
+     one paragraph; we don't need a grid here — the leading line is
+     visually distinct from the description that follows it. */
+  .cv :global(p strong:first-child) {
+    color: var(--ink);
+  }
+  .cv :global(p em) {
+    color: var(--ink-muted);
+    font-style: italic;
+  }
+
+  /* Two-column layout at the widest viewports: section labels hang
+     left of the role list, freeing the eye to scan the right column as
+     a single timeline. Achieved with a float — no extra wrappers, no
+     subgrid coordination across markdown structure. Needs ~1200px so
+     the gutter doesn't crash into the page-main edge. */
+  @media (min-width: 1200px) {
+    .cv :global(h3:not(:empty)) {
+      margin-left: -11rem;
+      width: 9.5rem;
+      float: left;
+      text-align: right;
+      font-size: var(--text-meta);
+      font-family: var(--font-mono);
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      text-transform: lowercase;
+      color: var(--ink-muted);
+      padding-top: 0.45rem;
+    }
+  }
+
+  /* Ordered list for Technical Skills — render as a wrapped row of
+     mono pills, NOT a numbered list. Source markdown is `1.`-prefixed
+     items by accident of the cv.md format. */
+  .cv :global(h3 + ol) {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 var(--space-md);
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+  .cv :global(h3 + ol li) {
+    margin: 0;
+  }
+  .cv :global(h3 + ol li::marker) {
+    content: none;
+  }
+
+  /* Unordered list — Projects. */
+  .cv :global(ul) {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 var(--space-md);
+  }
+  .cv :global(ul li) {
+    margin: 0 0 var(--space-md);
+    padding-left: var(--space-md);
+    position: relative;
+  }
+  .cv :global(ul li::before) {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.7em;
+    width: 0.4rem;
+    height: 1px;
+    background: var(--rule-strong);
+  }
+
+  /* Inline code — skills tagged with backticks (`Leadership`,
+     `Kubernetes`, `Swift`). Subtle mono pill, low-chroma surface tint.
+     NOT a coloured badge. */
+  .cv :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.86em;
+    padding: 0.08em 0.4em;
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-sm);
+    color: var(--ink);
+    white-space: nowrap;
+  }
+  .cv :global(a code) {
+    color: inherit;
+  }
+
+  /* Strong / em inside paragraphs already use the inherited body
+     family — no override needed beyond colour. */
+
+  /* Fallback variant. */
+  .cv--fallback {
     max-width: var(--measure);
+  }
+  .cv-fallback__socials {
+    margin: var(--space-md) 0 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    font-family: var(--font-mono);
+    font-size: var(--text-small);
+  }
+  .cv-fallback__diagnostic {
+    margin-top: var(--space-lg);
+    color: var(--ink-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+  }
+
+  /* ---------------------------------------------------------------- *
+   *  Narrow viewports — drop the gutter trick, stack everything.     *
+   * ---------------------------------------------------------------- */
+  @media (max-width: 1199px) {
+    .cv :global(h3:not(:empty)) {
+      font-size: var(--text-h3);
+      text-transform: none;
+      letter-spacing: -0.015em;
+    }
+  }
+
+  /* ---------------------------------------------------------------- *
+   *  Print — ink on white, no chrome, no decorative tinted surfaces. *
+   *  Hiring managers should be able to Save As PDF cleanly.          *
+   * ---------------------------------------------------------------- */
+  @media print {
+    :global(header.site-header),
+    :global(footer.site-footer),
+    :global(.theme-toggle),
+    :global(.skip-link) {
+      display: none !important;
+    }
+
+    :global(html),
+    :global(body) {
+      background: #fff !important;
+      color: #000 !important;
+    }
+
+    :global(.page-main) {
+      max-width: none;
+      padding: 0;
+    }
+
+    .cv {
+      color: #000;
+      font-size: 10.5pt;
+      line-height: 1.4;
+      max-width: none;
+    }
+
+    .cv :global(h1) {
+      font-size: 22pt;
+      margin-bottom: 0.1rem;
+    }
+    .cv :global(h1 + h2) {
+      font-size: 12pt;
+      color: #333;
+      margin-bottom: 0.6rem;
+    }
+    .cv :global(h3:not(:empty)) {
+      float: none;
+      margin: 0.5rem 0 0.25rem;
+      width: auto;
+      text-align: left;
+      font-size: 12pt;
+      font-family: var(--font-display);
+      text-transform: none;
+      letter-spacing: 0;
+      color: #000;
+      padding-top: 0;
+      border-bottom: 1px solid #999;
+      padding-bottom: 0.15rem;
+    }
+    .cv :global(h3:empty) {
+      height: 0.3rem;
+    }
+    .cv :global(hr) {
+      display: none;
+    }
+    .cv :global(a) {
+      color: #000;
+      text-decoration: none;
+    }
+    .cv :global(blockquote) {
+      color: #333;
+      font-size: 9pt;
+      margin-bottom: 0.8rem;
+    }
+    .cv :global(code) {
+      background: transparent;
+      border: 0;
+      padding: 0;
+      font-size: 0.95em;
+      color: #000;
+    }
+    .cv :global(p) {
+      margin: 0 0 0.3rem;
+    }
+    .cv :global(ul li::before) {
+      background: #000;
+    }
+    /* Avoid awkward page breaks inside a role block. */
+    .cv :global(h3),
+    .cv :global(p strong:first-child) {
+      break-after: avoid;
+    }
+    .cv :global(p),
+    .cv :global(li) {
+      break-inside: avoid;
+    }
   }
 </style>


### PR DESCRIPTION
## What

Replaces the `/cv/` stub introduced by #76 with a real, hiring-manager-friendly CV page sourced from the [cv repo](https://github.com/esttorhe/cv) as a git submodule.

- Adds `external/cv` as a submodule (pinned to `7a7825c`, current master HEAD)
- Reads `external/cv/cv.md` at build time via `node:fs/promises`
- Renders it with `marked` (added as a dev dep)
- Wraps the HTML in `BaseLayout` with `current="cv"`, sets a CV-flavoured `<title>` and `description`
- Authors a scoped style block over the existing OKLCH tokens — no new tokens introduced
- Adds a print stylesheet so hiring managers can Save As PDF cleanly
- Falls back to a polite "temporarily unavailable" message + contact links if the submodule isn't initialised, so the build never throws

## Why

PRODUCT.md's Hannah persona (hiring manager / founder, 60-second skim) is one of three equally-weighted audiences. The `/cv/` link surfaced in the nav by #76 currently lands on a stub. This issue closes that loop with a real CV that:

- carries voice via type (mono gutter labels, plainspoken hierarchy) rather than colored chrome,
- uses the existing token palette in both light and dark,
- reads as a CV, not as a blog post (denser body, no eyebrows, no SaaS-sidebar template, no numbered section markers — directly per the brief's anti-references),
- prints cleanly,
- doesn't break the rest of the site if the submodule is missing.

## Pin note

The issue requested pin `f388fd4` ("feat: add generic CV for recruiter screening"). No such commit exists in `git@github.com:esttorhe/cv.git` — the log goes through `dbe7ae3 feat: update CV with current work experience` and `7a7825c fix: restore Makefile to use weasyprint instead of Docker` (current HEAD on `master`). Pinned to `7a7825c` as the closest authoritative pin. Trivial to repoint with `git -C external/cv checkout <sha> && git add external/cv && git commit --amend` if a more specific commit lands upstream.

## Layout / register

- 1440+ (≥1200px): section labels (`work experience`, `projects`, `education`) hang in a mono right-aligned gutter to the left of the role list — gives the eye a single scannable timeline column on the right.
- 1024 / 768 / 375: section labels stack as normal headings; role descriptions flow full-width.
- Code-tagged skills (`Leadership`, `Kubernetes`, `Swift`, etc.) render as subtle mono pills with surface-tinted background and 1px rule. NOT colored badges.
- Both themes verified for AA contrast on body, muted, and accent inks against `--bg`.
- Print: header / footer / theme toggle / skip link all hidden, ink on white, role headings get a thin rule underneath, code pills drop their box. `break-inside: avoid` keeps role blocks intact across page breaks.

## For contributors

Clones of the repo now need:

\`\`\`sh
git submodule update --init --recursive
\`\`\`

If they skip it, the page renders the fallback instead of crashing the build.

## Test plan

- [x] `bun run build` passes (26 pages generated)
- [x] `bun run format:check` clean
- [x] Screenshots: 4 viewports (1440 / 1024 / 768 / 375) × 2 themes (light / dark) + 1 print preview at 1440 light. All read as CV, all show the role timeline correctly, dark theme passes contrast.
- [x] Submodule add → checkout → build → page renders → markdown content present in `dist/cv/index.html` (verified `Head of Engineering`, `Zenjob`, `Leadership` strings).
- [x] Submodule removed → build still passes, fallback renders with contact links.
- [x] Nav still highlights "CV" as `aria-current="page"` on `/cv/`.
- [ ] Manual sanity in browser by reviewer (dev server: `bun run dev`, then visit `/cv/`).
- [ ] Print preview in a real browser (Cmd-P → Save As PDF).

## Screenshots

Light, 1440 — note the mono gutter section labels:

![cv light 1440](.claude-visual/cv-light-1440.png)

Dark, 1440:

![cv dark 1440](.claude-visual/cv-dark-1440.png)

Light, 1024 — labels stack:

![cv light 1024](.claude-visual/cv-light-1024.png)

Light, 375:

![cv light 375](.claude-visual/cv-light-375.png)

Print:

![cv print](.claude-visual/cv-print.png)

Closes esttorhe_github_io-dqg.