### PR TITLE
Homepage polish: four minor sweeps from critique v2

### DIFF
--- a/src/components/marks/Sigil.astro
+++ b/src/components/marks/Sigil.astro
@@ -20,13 +20,7 @@ interface Props {
   id?: string;
 }
 
-const {
-  size = '0.78em',
-  title,
-  class: className = '',
-  decorative = true,
-  id,
-} = Astro.props;
+const { size = '0.78em', title, class: className = '', decorative = true, id } = Astro.props;
 
 const titleId = title ? (id ?? `sigil-title-${crypto.randomUUID()}`) : undefined;
 ---

--- a/src/components/marks/Sigil.astro
+++ b/src/components/marks/Sigil.astro
@@ -11,11 +11,24 @@ interface Props {
   class?: string;
   /** Decorative by default (aria-hidden). Set to false when the mark is semantic. */
   decorative?: boolean;
+  /**
+   * Explicit DOM id for the <title> when the mark is semantic. Pass one when
+   * `decorative={false}` to keep the id stable across renders. If omitted,
+   * we mint a build-time UUID; never `Math.random()` (non-deterministic
+   * between SSR and any future client hydration).
+   */
+  id?: string;
 }
 
-const { size = '0.78em', title, class: className = '', decorative = true } = Astro.props;
+const {
+  size = '0.78em',
+  title,
+  class: className = '',
+  decorative = true,
+  id,
+} = Astro.props;
 
-const titleId = title ? `sigil-title-${Math.random().toString(36).slice(2, 8)}` : undefined;
+const titleId = title ? (id ?? `sigil-title-${crypto.randomUUID()}`) : undefined;
 ---
 
 <svg

--- a/src/components/site/ThemeToggle.astro
+++ b/src/components/site/ThemeToggle.astro
@@ -100,15 +100,26 @@
     transform: rotate(0) scale(1);
   }
 
-  :global(html[data-theme='dark']) .theme-toggle__icon--sun,
-  :global(html.theme-dark-system) .theme-toggle__icon--sun {
+  :global(html[data-theme='dark']) .theme-toggle__icon--sun {
     opacity: 1;
     transform: rotate(0) scale(1);
   }
-  :global(html[data-theme='dark']) .theme-toggle__icon--moon,
-  :global(html.theme-dark-system) .theme-toggle__icon--moon {
+  :global(html[data-theme='dark']) .theme-toggle__icon--moon {
     opacity: 0;
     transform: rotate(90deg) scale(0.7);
+  }
+
+  /* No explicit choice + system is dark: mirror the dark-theme icon swap.
+     Matches the :root:not([data-theme]) palette block in global.css. */
+  @media (prefers-color-scheme: dark) {
+    :global(html:not([data-theme])) .theme-toggle__icon--sun {
+      opacity: 1;
+      transform: rotate(0) scale(1);
+    }
+    :global(html:not([data-theme])) .theme-toggle__icon--moon {
+      opacity: 0;
+      transform: rotate(90deg) scale(0.7);
+    }
   }
 
   .sr-only {
@@ -133,14 +144,10 @@
   }
 
   function syncToggleState() {
-    const root = document.documentElement;
-    const explicit = root.getAttribute('data-theme');
     const effective = effectiveTheme();
 
-    // Icon CSS already handles [data-theme='dark']; this class covers the
-    // "no explicit choice + system is dark" case so the sun shows correctly.
-    root.classList.toggle('theme-dark-system', explicit === null && effective === 'dark');
-
+    // Icon CSS handles both [data-theme='dark'] and the unset + system-dark
+    // case via a prefers-color-scheme media query; no class toggling needed.
     const button = document.querySelector<HTMLButtonElement>('[data-theme-toggle]');
     if (button) {
       const next = effective === 'dark' ? 'light' : 'dark';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,5 @@
 /* ABOUTME: Global stylesheet for estebantorr.es — OKLCH tokens, type system, motion, light + dark parity. */
-/* ABOUTME: The brand anchor is honey/amber (hue ~60°); body is Bricolage Grotesque, meta is Geist Mono. */
+/* ABOUTME: Honey/amber accent sits at hue 60; neutrals at hue 65 for a barely-warmer cast. Type: Bricolage + Geist Mono. */
 
 @import 'tailwindcss';
 
@@ -18,7 +18,9 @@
  * ---------------------------------------------------------------- */
 @layer base {
   :root {
-    /* Palette — light. Anchor: honey/amber, hue 60° (PRODUCT.md restrained strategy). */
+    /* Palette — light. Accent is honey/amber at hue 60°; neutrals sit at hue 65°
+       to keep a barely-warmer cast on the surfaces without pulling them into the
+       accent (the chroma is so low — 0.005–0.012 — the 5° offset is invisible). */
     --bg: oklch(1 0 0);
     --surface: oklch(0.965 0.006 65);
     --rule: oklch(0.88 0.008 65);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -141,6 +141,11 @@
     text-size-adjust: 100%;
     scroll-behavior: smooth;
     overflow-x: clip;
+    /* Pin the document font at <html> so anything that inherits before <body>
+       takes effect — head-injected nodes, dev toolbar containers, future
+       portals — picks Bricolage instead of the UA-default sans cascade
+       (ui-sans-serif, "Apple Color Emoji", ...). */
+    font-family: var(--font-body);
   }
 
   body {


### PR DESCRIPTION
Round-2 polish sweep of the four minor observations from the v2 critique snapshot. Each item is its own commit so reverts and follow-up reviews stay surgical.

Closes esttorhe_github_io-te7.

## Cleanups

- [x] **Dead `theme-dark-system` class removed.** `ThemeToggle.astro` no longer toggles a class for "no explicit choice + system is dark" — the matching palette path is already covered by `:root:not([data-theme])` in `global.css`. Replaced the class-gated icon swap with a `prefers-color-scheme: dark` media query so the sun still appears for system-dark visitors who haven't picked a theme. (`refactor(theme): remove dead theme-dark-system class`)

- [x] **`Math.random()` removed from Sigil title id.** `Sigil.astro` now accepts an optional `id` prop and falls back to `crypto.randomUUID()` (Node, SSR only) when one isn't passed. Eliminates the SSR↔client mismatch risk if the Sigil is ever rendered inside a client component. Current decorative usage is unchanged. (`fix(sigil): replace Math.random() title id with stable id prop`)

- [x] **Accent-hue comment corrected.** The header and palette comments implied a single hue ~60° while the neutrals actually sit at hue 65 and the accent at hue 60. Comment now reflects reality: accent 60, neutrals 65, with a note that the chroma is so low (0.005–0.012) the 5° offset is invisible. Zero visual change. (`docs(tokens): correct accent-hue comment in global.css`)

- [x] **UA-default sans font leak plugged.** Puppeteer's font-family sweep reported three distinct computed values on the homepage — Bricolage, Geist Mono, and a `ui-sans-serif, "Apple Color Emoji", ...` UA-default stack landing on `<html>`, `<head>`, and `<script>` nodes. PR #75's form-control reset didn't catch it because there are no form controls on the page. Pinned `font-family: var(--font-body)` on `<html>` so anything inheriting before `<body>` (head-injected nodes, dev toolbar, future portals) picks Bricolage. Sweep now reports 2 unique families on both themes. (`fix(global): pin font-family on html to plug UA-default sans leak`)

Plus one `style(sigil): apply prettier formatting` follow-up after the format pass.

## Verification

- `bun run build` clean on every commit (26 pages).
- `bun run format` clean.
- Puppeteer audit on `bun astro dev`:
  - Before: 3 unique computed `font-family` values (leak = `ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", …` on 40 nodes).
  - After: 2 unique computed `font-family` values (Bricolage + Geist Mono) on both `light` and `dark`.
- 1440-wide screenshots: `.claude-visual/polish-v2-light.png`, `.claude-visual/polish-v2-dark.png` — no visual regressions; theme toggle icon still flips correctly in both directions.

## Merge order

Expected to rebase against the other five `homepage-v2` PRs; merge me last.