### PR TITLE
feat(article): craft post template — Vollkorn serif, dual-theme Shiki, 4 shortcodes, lazy comments

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,10 @@ export default defineConfig({
   integrations: [mdx(), sitemap()],
   markdown: {
     shikiConfig: {
-      theme: 'github-dark',
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark',
+      },
       wrap: true,
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "tailwindcss": "^4.1.18",
       },
       "devDependencies": {
+        "@fontsource/vollkorn": "^5.2.10",
         "marked": "^18.0.5",
         "prettier": "^3.8.4",
         "prettier-plugin-astro": "^0.14.1",
@@ -109,6 +110,8 @@
     "@fontsource-variable/inter": ["@fontsource-variable/inter@5.2.8", "", {}, "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="],
 
     "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.7", "", {}, "sha512-xVPVFISJg/K0VVd+aQN0Y7X/sw9hUcJPyDWFJ5GpyU3bHELhoRsJkPSRSHXW32mOi0xZCUQDOaPj1sqIFJ1FGg=="],
+
+    "@fontsource/vollkorn": ["@fontsource/vollkorn@5.2.10", "", {}, "sha512-gSlz1yYmGkpSnfchXwbdkCnGFGnV2lKhA0Wc87kF95kA5ziOGLHCriQvDKZhExVC4/heeB6MdmVdyIW/e9Ab6A=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {
+    "@fontsource/vollkorn": "^5.2.10",
     "marked": "^18.0.5",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",

--- a/src/components/article/Comments.astro
+++ b/src/components/article/Comments.astro
@@ -1,0 +1,175 @@
+---
+// ABOUTME: utteranc.es comment widget, lazy-loaded via IntersectionObserver so the iframe doesn't block first paint.
+// ABOUTME: Theme tracks the page theme (icy-dark in dark, github-light in light) via postMessage on toggle.
+
+interface Props {
+  /** GitHub repo holding the comment issues (owner/repo). */
+  repo?: string;
+  /** Issue label new comments are filed under. */
+  label?: string;
+  /** Issue-mapping strategy. See https://utteranc.es. */
+  issueTerm?: 'pathname' | 'url' | 'title' | 'og:title';
+}
+
+const {
+  repo = 'esttorhe/esttorhe.github.io',
+  label = 'Comments',
+  issueTerm = 'title',
+} = Astro.props;
+---
+
+<section class="comments" aria-labelledby="comments-heading">
+  <header class="comments__header">
+    <h2 id="comments-heading" class="comments__title">Comments</h2>
+    <p class="comments__sub">
+      Threaded via <a href="https://utteranc.es" rel="noopener noreferrer">utteranc.es</a> on GitHub issues.
+      A GitHub account is required to comment.
+    </p>
+  </header>
+
+  <div
+    class="comments__mount"
+    data-utterances-mount
+    data-repo={repo}
+    data-label={label}
+    data-issue-term={issueTerm}
+  >
+    <p class="comments__placeholder">Loading comments…</p>
+  </div>
+</section>
+
+<style>
+  .comments {
+    margin-top: var(--space-2xl);
+    padding-top: var(--space-lg);
+    border-top: 1px solid var(--rule);
+    max-width: var(--measure);
+  }
+
+  .comments__title {
+    font-family: var(--font-display);
+    font-size: var(--text-h3);
+    font-weight: 600;
+    margin: 0;
+    color: var(--ink);
+  }
+
+  .comments__sub {
+    margin: var(--space-xs) 0 var(--space-md);
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+  }
+
+  .comments__sub a {
+    color: var(--ink-muted);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in oklab, var(--accent) 45%, transparent);
+    text-underline-offset: 0.2em;
+  }
+
+  .comments__sub a:hover,
+  .comments__sub a:focus-visible {
+    color: var(--accent-ink);
+  }
+
+  .comments__mount {
+    min-height: 4rem;
+  }
+
+  .comments__placeholder {
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+    margin: 0;
+  }
+
+  /* utteranc.es injects its own .utterances iframe; we just give it room. */
+  .comments__mount :global(.utterances) {
+    max-width: 100%;
+    margin: 0;
+  }
+
+  .comments__mount.is-loaded .comments__placeholder {
+    display: none;
+  }
+</style>
+
+<script>
+  // Lazy-load utteranc.es: only inject the script when the comments section enters
+  // the viewport. Re-themes on every theme toggle via postMessage to the iframe.
+
+  function utterancesThemeFor(documentTheme: string): string {
+    return documentTheme === 'dark' ? 'icy-dark' : 'github-light';
+  }
+
+  function getDocumentTheme(): 'light' | 'dark' {
+    const explicit = document.documentElement.getAttribute('data-theme');
+    if (explicit === 'light' || explicit === 'dark') return explicit;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+
+  function mountUtterances(mount: HTMLElement) {
+    if (mount.dataset.utterancesMounted === 'true') return;
+    mount.dataset.utterancesMounted = 'true';
+
+    const script = document.createElement('script');
+    script.src = 'https://utteranc.es/client.js';
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute('repo', mount.dataset.repo ?? '');
+    script.setAttribute('issue-term', mount.dataset.issueTerm ?? 'title');
+    if (mount.dataset.label) script.setAttribute('label', mount.dataset.label);
+    script.setAttribute('theme', utterancesThemeFor(getDocumentTheme()));
+
+    script.addEventListener('load', () => mount.classList.add('is-loaded'));
+    mount.appendChild(script);
+  }
+
+  function syncThemeToIframe() {
+    const iframe = document.querySelector<HTMLIFrameElement>('iframe.utterances-frame');
+    if (!iframe || !iframe.contentWindow) return;
+    iframe.contentWindow.postMessage(
+      { type: 'set-theme', theme: utterancesThemeFor(getDocumentTheme()) },
+      'https://utteranc.es',
+    );
+  }
+
+  function wire() {
+    const mount = document.querySelector<HTMLElement>('[data-utterances-mount]');
+    if (!mount) return;
+
+    if ('IntersectionObserver' in window) {
+      const obs = new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              mountUtterances(mount);
+              obs.disconnect();
+              break;
+            }
+          }
+        },
+        { rootMargin: '300px 0px' },
+      );
+      obs.observe(mount);
+    } else {
+      // Fallback: just mount on idle.
+      ('requestIdleCallback' in window
+        ? (cb: () => void) =>
+            (window as Window & typeof globalThis).requestIdleCallback(cb, { timeout: 2000 })
+        : (cb: () => void) => setTimeout(cb, 1500))(() => mountUtterances(mount));
+    }
+  }
+
+  wire();
+  document.addEventListener('astro:page-load', wire);
+
+  // Re-theme the iframe whenever the user toggles the page theme.
+  const observer = new MutationObserver(syncThemeToIframe);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', syncThemeToIframe);
+</script>

--- a/src/components/article/PostNav.astro
+++ b/src/components/article/PostNav.astro
@@ -1,0 +1,169 @@
+---
+// ABOUTME: Post-end navigation: "Next read" + "Previously" + "All writing →".
+// ABOUTME: Uses the same hover grammar as homepage lists (pointer translate + accent-ink title shift).
+
+import type { CollectionEntry } from 'astro:content';
+
+interface Props {
+  next?: CollectionEntry<'blog'>;
+  previous?: CollectionEntry<'blog'>;
+}
+
+const { next, previous } = Astro.props;
+
+function postHref(post: CollectionEntry<'blog'>) {
+  const date = new Date(post.data.date);
+  const year = String(date.getFullYear());
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const titleSlug = post.id.replace(/^\d{4}-\d{2}-/, '').replace(/\.mdx?$/, '');
+  return `/${year}/${month}/${titleSlug}/`;
+}
+---
+
+<nav class="post-nav" aria-label="More writing">
+  <ul class="post-nav__list">
+    {
+      next && (
+        <li class="post-nav__item">
+          <a class="post-nav__link" href={postHref(next)} rel="next">
+            <span class="post-nav__framing">Next read</span>
+            <span class="post-nav__pointer" aria-hidden="true">
+              →
+            </span>
+            <span class="post-nav__title">{next.data.title}</span>
+          </a>
+        </li>
+      )
+    }
+    {
+      previous && (
+        <li class="post-nav__item">
+          <a class="post-nav__link" href={postHref(previous)} rel="prev">
+            <span class="post-nav__framing">Previously</span>
+            <span class="post-nav__pointer" aria-hidden="true">
+              ←
+            </span>
+            <span class="post-nav__title">{previous.data.title}</span>
+          </a>
+        </li>
+      )
+    }
+    <li class="post-nav__item post-nav__item--all">
+      <a class="post-nav__link post-nav__link--meta" href="/blog/">
+        <span class="post-nav__framing">All writing</span>
+        <span class="post-nav__pointer" aria-hidden="true">→</span>
+      </a>
+    </li>
+  </ul>
+</nav>
+
+<style>
+  .post-nav {
+    margin-top: var(--space-2xl);
+    padding-top: var(--space-lg);
+    border-top: 1px solid var(--rule);
+    max-width: var(--measure);
+  }
+
+  .post-nav__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .post-nav__item {
+    margin: 0;
+  }
+
+  .post-nav__link {
+    display: grid;
+    grid-template-columns: minmax(8rem, max-content) auto 1fr;
+    grid-template-areas: 'framing pointer title';
+    column-gap: var(--space-sm);
+    align-items: baseline;
+    padding: 0.625rem 0;
+    text-decoration: none;
+    color: var(--ink);
+    border-bottom: 1px solid transparent;
+    transition:
+      border-color var(--duration-fast) var(--ease-out-quart),
+      color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .post-nav__link:hover,
+  .post-nav__link:focus-visible {
+    border-color: var(--rule-strong);
+    outline: none;
+  }
+
+  .post-nav__link:hover .post-nav__pointer,
+  .post-nav__link:focus-visible .post-nav__pointer {
+    transform: translateX(0.25rem);
+    color: var(--accent);
+  }
+
+  .post-nav__link[rel='prev']:hover .post-nav__pointer,
+  .post-nav__link[rel='prev']:focus-visible .post-nav__pointer {
+    transform: translateX(-0.25rem);
+  }
+
+  .post-nav__link:hover .post-nav__title,
+  .post-nav__link:focus-visible .post-nav__title {
+    color: var(--accent-ink);
+  }
+
+  .post-nav__framing {
+    grid-area: framing;
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+    letter-spacing: 0.005em;
+  }
+
+  .post-nav__pointer {
+    grid-area: pointer;
+    color: var(--ink-muted);
+    font-family: var(--font-mono);
+    transform: translateX(0);
+    transition:
+      transform var(--duration-fast) var(--ease-out-quart),
+      color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .post-nav__title {
+    grid-area: title;
+    font-family: var(--font-display);
+    font-weight: 500;
+    font-size: var(--text-body);
+    line-height: 1.3;
+    transition: color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .post-nav__link--meta {
+    grid-template-columns: max-content auto;
+    grid-template-areas: 'framing pointer';
+    color: var(--ink-muted);
+  }
+
+  .post-nav__item--all {
+    margin-top: var(--space-xs);
+  }
+
+  @media (max-width: 540px) {
+    .post-nav__link {
+      grid-template-columns: auto 1fr;
+      grid-template-areas:
+        'framing framing'
+        'pointer title';
+      column-gap: var(--space-xs);
+      row-gap: 0.25rem;
+    }
+    .post-nav__link--meta {
+      grid-template-columns: max-content auto;
+      grid-template-areas: 'framing pointer';
+    }
+  }
+</style>

--- a/src/components/shortcodes/Blockquote.astro
+++ b/src/components/shortcodes/Blockquote.astro
@@ -1,6 +1,6 @@
 ---
-// ABOUTME: Pull-quote / blockquote shortcode used inside MDX posts.
-// ABOUTME: Visuals deliberately bare; final styling lands during /impeccable shape + craft.
+// ABOUTME: Pull-quote shortcode used inside MDX posts. Typographic, not a card.
+// ABOUTME: Renders an oversized opening curly-quote as the visual anchor (NO side-stripe per absolute bans).
 
 interface Props {
   cite?: string;
@@ -11,7 +11,9 @@ const { cite, source } = Astro.props;
 ---
 
 <figure class="shortcode-quote">
-  <blockquote cite={source}><slot /></blockquote>
+  <blockquote cite={source}>
+    <slot />
+  </blockquote>
   {
     (cite || source) && (
       <figcaption>
@@ -28,3 +30,72 @@ const { cite, source } = Astro.props;
     )
   }
 </figure>
+
+<style>
+  .shortcode-quote {
+    position: relative;
+    margin: var(--space-lg) 0;
+    padding-inline-start: clamp(var(--space-md), 5vw, var(--space-xl));
+    max-width: var(--measure);
+  }
+
+  /* Oversized opening curly quote in the brand accent — typographic anchor,
+     not a stripe. Positioned absolutely so the body text starts at the
+     section margin even when the quote glyph hangs left. */
+  .shortcode-quote::before {
+    content: '\201C'; /* left double quotation mark */
+    position: absolute;
+    inset-inline-start: -0.05em;
+    top: -0.35em;
+    font-family: var(--font-display);
+    font-size: clamp(3.5rem, 2rem + 4vw, 5rem);
+    line-height: 1;
+    color: var(--accent);
+    opacity: 0.55;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .shortcode-quote blockquote {
+    margin: 0;
+    padding: 0;
+    font-family: var(--font-prose);
+    font-style: italic;
+    font-size: var(--text-prose-lead);
+    line-height: 1.5;
+    color: var(--ink);
+    text-wrap: pretty;
+  }
+
+  .shortcode-quote blockquote :is(p) {
+    margin: 0;
+    max-width: none;
+  }
+
+  .shortcode-quote figcaption {
+    margin-top: var(--space-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+    letter-spacing: 0.005em;
+  }
+
+  .shortcode-quote figcaption::before {
+    content: '\2014 \00a0'; /* em-dash + nbsp */
+    color: var(--ink-muted);
+  }
+
+  .shortcode-quote figcaption a {
+    color: var(--ink-muted);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in oklab, var(--accent) 50%, transparent);
+    text-underline-offset: 0.2em;
+    transition: color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .shortcode-quote figcaption a:hover,
+  .shortcode-quote figcaption a:focus-visible {
+    color: var(--accent-ink);
+    text-decoration-color: currentColor;
+  }
+</style>

--- a/src/components/shortcodes/GitHubRepo.astro
+++ b/src/components/shortcodes/GitHubRepo.astro
@@ -1,6 +1,6 @@
 ---
-// ABOUTME: GitHub repo link shortcode used inside MDX posts.
-// ABOUTME: Visuals deliberately bare; final styling lands during /impeccable shape + craft.
+// ABOUTME: GitHub repo / commit link shortcode used inside MDX posts.
+// ABOUTME: Inline mono pill with octicon + owner/repo + short commit hash.
 
 interface Props {
   owner: string;
@@ -16,7 +16,95 @@ const shortCommit = commit ? commit.slice(0, 7) : undefined;
 ---
 
 <a class="shortcode-github" href={href} rel="noopener noreferrer" target="_blank">
-  <span class="repo-owner">{owner}</span>/<span class="repo-name">{repo}</span>{
-    shortCommit && <span class="repo-commit"> @ {shortCommit}</span>
+  <svg
+    class="shortcode-github__icon"
+    viewBox="0 0 16 16"
+    aria-hidden="true"
+    width="14"
+    height="14"
+    fill="currentColor"
+  >
+    <path
+      d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+    ></path>
+  </svg>
+  <span class="shortcode-github__path">
+    <span class="shortcode-github__owner">{owner}</span><span class="shortcode-github__slash"
+      >/</span
+    ><span class="shortcode-github__repo">{repo}</span>
+  </span>
+  {
+    shortCommit && (
+      <>
+        <span aria-hidden="true" class="shortcode-github__sep">
+          @
+        </span>
+        <span class="shortcode-github__commit">{shortCommit}</span>
+      </>
+    )
   }
 </a>
+
+<style>
+  .shortcode-github {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45ch;
+    padding: 0.15em 0.55em 0.2em;
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    line-height: 1.4;
+    color: var(--ink);
+    text-decoration: none;
+    vertical-align: baseline;
+    transition:
+      border-color var(--duration-fast) var(--ease-out-quart),
+      background var(--duration-fast) var(--ease-out-quart),
+      color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .shortcode-github:hover,
+  .shortcode-github:focus-visible {
+    border-color: var(--accent);
+    background: var(--bg);
+    color: var(--accent-ink);
+    outline: none;
+  }
+
+  .shortcode-github__icon {
+    flex-shrink: 0;
+    color: var(--ink-muted);
+    transition: color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .shortcode-github:hover .shortcode-github__icon,
+  .shortcode-github:focus-visible .shortcode-github__icon {
+    color: currentColor;
+  }
+
+  .shortcode-github__owner {
+    color: var(--ink-muted);
+  }
+
+  .shortcode-github__slash {
+    color: var(--ink-muted);
+    opacity: 0.55;
+  }
+
+  .shortcode-github__repo {
+    font-weight: 500;
+  }
+
+  .shortcode-github__sep {
+    color: var(--ink-muted);
+    opacity: 0.55;
+  }
+
+  .shortcode-github__commit {
+    color: var(--ink-muted);
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/components/shortcodes/Terminal.astro
+++ b/src/components/shortcodes/Terminal.astro
@@ -1,6 +1,6 @@
 ---
-// ABOUTME: Terminal / shell session shortcode used inside MDX posts.
-// ABOUTME: Visuals deliberately bare; final styling lands during /impeccable shape + craft.
+// ABOUTME: Shell / terminal session shortcode used inside MDX posts.
+// ABOUTME: Mono block with a subtle prompt glyph; no macOS chrome, no traffic lights.
 
 interface Props {
   prompt?: string;
@@ -9,4 +9,55 @@ interface Props {
 const { prompt = '$' } = Astro.props;
 ---
 
-<pre class="shortcode-terminal" data-prompt={prompt}><code><slot /></code></pre>
+<figure class="shortcode-terminal" data-prompt={prompt}>
+  <pre><code><slot /></code></pre>
+</figure>
+
+<style>
+  .shortcode-terminal {
+    margin: var(--space-lg) 0;
+    padding: var(--space-md) var(--space-md) var(--space-md) calc(var(--space-md) + 1.4em);
+    background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-md);
+    position: relative;
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: var(--text-small);
+    line-height: 1.55;
+    color: var(--ink);
+  }
+
+  /* Subtle prompt glyph hanging at the start, in the accent.
+     No traffic-light chrome, no macOS-window header. */
+  .shortcode-terminal::before {
+    content: attr(data-prompt);
+    position: absolute;
+    inset-inline-start: var(--space-md);
+    top: calc(var(--space-md) + 0.05em);
+    color: var(--accent);
+    font-weight: 500;
+    user-select: none;
+    pointer-events: none;
+  }
+
+  .shortcode-terminal pre {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
+    overflow: visible;
+  }
+
+  .shortcode-terminal code {
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    padding: 0;
+    border: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+</style>

--- a/src/components/shortcodes/TweetQuote.astro
+++ b/src/components/shortcodes/TweetQuote.astro
@@ -1,6 +1,6 @@
 ---
 // ABOUTME: Archived tweet shortcode used inside MDX posts (no live Twitter embed).
-// ABOUTME: Visuals deliberately bare; final styling lands during /impeccable shape + craft.
+// ABOUTME: Renders as a dated, attributed quote — not a tweet-card replica.
 
 interface Props {
   author: string;
@@ -13,10 +13,104 @@ const handleUrl = `https://twitter.com/${username}`;
 ---
 
 <figure class="shortcode-tweet">
-  <blockquote><slot /></blockquote>
+  <blockquote>
+    <slot />
+  </blockquote>
   <figcaption>
     <span class="tweet-author">{author}</span>
+    <span aria-hidden="true" class="tweet-sep">·</span>
     <a class="tweet-handle" href={handleUrl} rel="noopener noreferrer">@{username}</a>
-    {date && <time class="tweet-date">{date}</time>}
+    {
+      date && (
+        <>
+          <span aria-hidden="true" class="tweet-sep">
+            ·
+          </span>
+          <time class="tweet-date">{date}</time>
+        </>
+      )
+    }
   </figcaption>
 </figure>
+
+<style>
+  .shortcode-tweet {
+    margin: var(--space-lg) 0;
+    padding: var(--space-md) 0 var(--space-md) clamp(var(--space-md), 4vw, var(--space-lg));
+    max-width: var(--measure);
+    position: relative;
+  }
+
+  /* A small ringed-dot anchor on the left, evoking the Sigil without re-importing it
+     here (avoids coupling shortcodes to the marks/ directory). */
+  .shortcode-tweet::before {
+    content: '';
+    position: absolute;
+    inset-inline-start: 0;
+    top: calc(var(--space-md) + 0.5em);
+    width: 0.65em;
+    height: 0.65em;
+    border: 1.5px solid var(--accent);
+    border-radius: 50%;
+    background: radial-gradient(circle, var(--accent) 0 30%, transparent 32%);
+    opacity: 0.85;
+  }
+
+  .shortcode-tweet blockquote {
+    margin: 0;
+    padding: 0;
+    font-family: var(--font-prose);
+    font-size: var(--text-prose);
+    font-style: italic;
+    line-height: 1.55;
+    color: var(--ink);
+    text-wrap: pretty;
+  }
+
+  .shortcode-tweet blockquote :is(p) {
+    margin: 0 0 var(--space-xs);
+    max-width: none;
+  }
+
+  .shortcode-tweet blockquote :is(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .shortcode-tweet figcaption {
+    margin-top: var(--space-sm);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5ch;
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+  }
+
+  .shortcode-tweet .tweet-author {
+    color: var(--ink);
+    font-weight: 500;
+  }
+
+  .shortcode-tweet .tweet-sep {
+    opacity: 0.55;
+  }
+
+  .shortcode-tweet .tweet-handle {
+    color: var(--ink-muted);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in oklab, var(--accent) 45%, transparent);
+    text-underline-offset: 0.2em;
+    transition: color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .shortcode-tweet .tweet-handle:hover,
+  .shortcode-tweet .tweet-handle:focus-visible {
+    color: var(--accent-ink);
+    text-decoration-color: currentColor;
+  }
+
+  .shortcode-tweet .tweet-date {
+    font-variant-numeric: tabular-nums;
+  }
+</style>

--- a/src/pages/[year]/[month]/[...slug].astro
+++ b/src/pages/[year]/[month]/[...slug].astro
@@ -1,50 +1,129 @@
 ---
-// ABOUTME: Blog post template preserving Hugo's permalink shape (/:year/:month/:title/).
-// ABOUTME: Bare semantic markup; typography, code-block treatment, TOC, footer pathing land during /impeccable shape + craft.
+// ABOUTME: Blog post template — Vollkorn serif prose body (styles in global.css), Bricolage display headings, dual-theme Shiki.
+// ABOUTME: Permalink shape preserves Hugo's /:year/:month/:title/. Lazy utteranc.es comments at the bottom.
 
 import BaseLayout from '../../../layouts/BaseLayout.astro';
-import { getCollection, render } from 'astro:content';
+import PostNav from '../../../components/article/PostNav.astro';
+import Comments from '../../../components/article/Comments.astro';
+import { getCollection, render, type CollectionEntry } from 'astro:content';
 import type { GetStaticPaths } from 'astro';
 
+type Post = CollectionEntry<'blog'>;
+
 export const getStaticPaths = (async () => {
-  const posts = await getCollection('blog', ({ data }) => !data.draft);
-  return posts.map((post) => {
+  const posts = (await getCollection('blog', ({ data }) => !data.draft)).sort(
+    (a, b) => +b.data.date - +a.data.date,
+  );
+
+  return posts.map((post, idx) => {
     const date = new Date(post.data.date);
     const year = String(date.getFullYear());
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const titleSlug = post.id.replace(/^\d{4}-\d{2}-/, '').replace(/\.mdx?$/, '');
     return {
       params: { year, month, slug: titleSlug },
-      props: { post },
+      props: {
+        post,
+        // posts sorted newest-first: next-chronological is idx - 1, previous is idx + 1
+        next: posts[idx - 1] as Post | undefined,
+        previous: posts[idx + 1] as Post | undefined,
+      },
     };
   });
 }) satisfies GetStaticPaths;
 
-const { post } = Astro.props;
+const { post, next, previous } = Astro.props;
 const { Content } = await render(post);
 
 const date = new Date(post.data.date);
-const readingMinutes = Math.max(1, Math.ceil((post.body ?? '').split(/\s+/).length / 200));
+const readingMinutes = Math.max(
+  1,
+  Math.ceil((post.body ?? '').split(/\s+/).filter(Boolean).length / 220),
+);
+
+const dateFormat = new Intl.DateTimeFormat('en-GB', {
+  year: 'numeric',
+  month: 'long',
+  day: '2-digit',
+});
 ---
 
-<BaseLayout title={post.data.title} description={post.data.description}>
-  <article>
-    <header>
-      <h1>{post.data.title}</h1>
-      <p class="post-meta">
-        <time datetime={date.toISOString()}>
-          {date.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: '2-digit' })}
+<BaseLayout title={post.data.title} description={post.data.description} current="writing">
+  <article class="article">
+    <header class="article__header reveal">
+      <p class="article__meta">
+        <time datetime={date.toISOString()} class="article__date tabular">
+          {dateFormat.format(date)}
         </time>
-        <span>·</span>
-        <span class="post-category">{post.data.category}</span>
-        <span>·</span>
-        <span class="post-reading">{readingMinutes} min read</span>
+        <span aria-hidden="true" class="article__sep">·</span>
+        <span class="article__category">{post.data.category}</span>
+        <span aria-hidden="true" class="article__sep">·</span>
+        <span class="article__reading tabular">{readingMinutes} min read</span>
       </p>
-      {post.data.description && <p class="post-lede">{post.data.description}</p>}
+      <h1 class="article__title">{post.data.title}</h1>
+      {post.data.description && <p class="article__lede">{post.data.description}</p>}
     </header>
 
-    <div class="post-body">
+    <div class="prose">
       <Content />
     </div>
+
+    <PostNav next={next} previous={previous} />
+    <Comments />
   </article>
 </BaseLayout>
+
+<style>
+  .article {
+    max-width: var(--max-content);
+    margin: 0 auto;
+    padding-top: var(--space-md);
+  }
+
+  .article__header {
+    max-width: var(--measure);
+    margin-bottom: var(--space-xl);
+  }
+
+  .article__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5ch;
+    margin: 0 0 var(--space-md);
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+  }
+
+  .article__sep {
+    opacity: 0.55;
+  }
+
+  .article__category,
+  .article__date,
+  .article__reading {
+    color: var(--ink-muted);
+  }
+
+  .article__title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: var(--text-h1);
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    color: var(--ink);
+    margin: 0;
+    text-wrap: balance;
+  }
+
+  .article__lede {
+    font-family: var(--font-prose);
+    font-size: var(--text-prose-lead);
+    line-height: 1.4;
+    color: var(--ink-muted);
+    margin: var(--space-md) 0 0;
+    max-width: var(--measure);
+    text-wrap: pretty;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,6 +12,11 @@
 @import '@fontsource-variable/bricolage-grotesque/standard.css';
 @import '@fontsource/geist-mono/400.css';
 @import '@fontsource/geist-mono/500.css';
+/* Vollkorn: humanist serif used ONLY for article body prose (post template).
+   Imported as 400 + 400-italic + 600 — the four weights an article actually needs. */
+@import '@fontsource/vollkorn/400.css';
+@import '@fontsource/vollkorn/400-italic.css';
+@import '@fontsource/vollkorn/600.css';
 
 /* ---------------------------------------------------------------- *
  *  Tokens.                                                         *
@@ -39,6 +44,9 @@
       'Bricolage Grotesque Variable', ui-sans-serif, system-ui, -apple-system, 'Segoe UI',
       sans-serif;
     --font-mono: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    /* Prose-only serif. Scoped to .prose / article body via the post template; the
+       rest of the site stays single-family Bricolage. */
+    --font-prose: 'Vollkorn', Georgia, 'Iowan Old Style', 'Charter', 'Times New Roman', serif;
 
     /* Type scale. Body fixed; display + headings fluid via clamp(). */
     --text-meta: 0.8125rem; /* 13px — dates, kickers, footer */
@@ -49,6 +57,11 @@
     --text-h2: clamp(1.5rem, 1.25rem + 1vw, 2.125rem);
     --text-h1: clamp(1.875rem, 1.25rem + 2.5vw, 3.5rem);
     --text-display: clamp(2rem, 1rem + 3vw, 5rem);
+    /* Prose-only scale. Vollkorn renders ~0.5–1px smaller perceptually than
+       Bricolage at the same px, so prose body is bumped to 18px (vs 17 sans). */
+    --text-prose: 1.125rem; /* 18px — article body */
+    --text-prose-lead: clamp(1.1875rem, 1rem + 0.6vw, 1.4375rem);
+    --leading-prose: 1.65;
 
     /* Spacing — rhythm built on 1.5rem multiples (≈24px), the body line-height. */
     --space-2xs: 0.25rem;
@@ -382,66 +395,233 @@
 }
 
 /* ---------------------------------------------------------------- *
- *  Shortcode placeholders — kept minimal until /impeccable craft   *
- *  passes individually shape them.                                 *
+ *  Article body prose — Vollkorn serif, used inside `.prose`.       *
+ *  Loaded globally so MDX-rendered markup (which Astro doesn't hash) *
+ *  picks up the styles. Shortcodes carry their own scoped styles.    *
  * ---------------------------------------------------------------- */
 @layer components {
-  .shortcode-quote {
-    margin: var(--space-md) 0;
+  .prose {
     max-width: var(--measure);
-  }
-  .shortcode-quote blockquote {
-    margin: 0;
-    padding: var(--space-xs) 0 var(--space-xs) var(--space-md);
-    font-style: italic;
-  }
-  .shortcode-quote figcaption {
-    margin-top: var(--space-xs);
-    font-size: var(--text-small);
-    color: var(--ink-muted);
+    font-family: var(--font-prose);
+    font-size: var(--text-prose);
+    line-height: var(--leading-prose);
+    color: var(--ink);
+    font-kerning: normal;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
-  .shortcode-terminal {
-    margin: var(--space-md) 0;
-    padding: var(--space-md);
-    background: var(--surface);
-    border: 1px solid var(--rule);
-    border-radius: var(--radius-md);
-    overflow-x: auto;
-    font-size: var(--text-small);
+  .prose > * + * {
+    margin-top: var(--space-md);
   }
 
-  .shortcode-tweet {
-    margin: var(--space-md) 0;
-    padding: var(--space-md);
-    border: 1px solid var(--rule);
-    border-radius: var(--radius-md);
-    max-width: var(--measure);
+  .prose > h2 {
+    margin-top: var(--space-xl);
   }
-  .shortcode-tweet blockquote {
-    margin: 0 0 var(--space-xs);
-  }
-  .shortcode-tweet figcaption {
-    font-size: var(--text-small);
-    color: var(--ink-muted);
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-xs);
+  .prose > h3 {
+    margin-top: var(--space-lg);
   }
 
-  .shortcode-github {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 0.15em;
-    padding: 0.15em 0.4em;
-    border: 1px solid var(--rule);
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.95em;
-    text-decoration: none;
+  .prose h2,
+  .prose h3,
+  .prose h4,
+  .prose h5,
+  .prose h6 {
+    font-family: var(--font-display);
+    font-weight: 700;
+    line-height: 1.18;
+    letter-spacing: -0.02em;
+    color: var(--ink);
+    text-wrap: balance;
+    margin-bottom: var(--space-sm);
+  }
+
+  .prose h2 {
+    font-size: var(--text-h2);
+  }
+  .prose h3 {
+    font-size: var(--text-h3);
+    letter-spacing: -0.01em;
+  }
+  .prose h4 {
+    font-size: var(--text-body);
+  }
+
+  .prose p {
+    margin: 0 0 var(--space-md);
+    max-width: none;
+    text-wrap: pretty;
+    hyphens: auto;
+  }
+
+  .prose strong {
+    font-weight: 600;
     color: var(--ink);
   }
-  .shortcode-github:hover {
+  .prose em {
+    font-style: italic;
+  }
+
+  .prose a {
+    color: var(--accent-ink);
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-decoration-color: color-mix(in oklab, var(--accent) 55%, transparent);
+    text-underline-offset: 0.2em;
+    transition:
+      text-decoration-color var(--duration-fast) var(--ease-out-quart),
+      text-decoration-thickness var(--duration-fast) var(--ease-out-quart);
+  }
+  .prose a:hover,
+  .prose a:focus-visible {
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 2px;
+  }
+
+  .prose ul,
+  .prose ol {
+    margin: 0 0 var(--space-md);
+    padding-inline-start: var(--space-lg);
+    max-width: none;
+  }
+  .prose ul > li,
+  .prose ol > li {
+    margin: 0 0 var(--space-xs);
+  }
+  .prose ul > li::marker {
+    color: var(--accent);
+  }
+  .prose ol > li::marker {
+    color: var(--ink-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .prose li > ul,
+  .prose li > ol {
+    margin-top: var(--space-xs);
+  }
+
+  .prose > blockquote {
+    margin: var(--space-lg) 0;
+    padding-inline-start: var(--space-md);
+    color: var(--ink-muted);
+    font-style: italic;
+    border-left: 1px solid var(--rule-strong);
+  }
+
+  .prose code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    padding: 0.12em 0.4em;
     background: var(--surface);
+    border: 1px solid var(--rule);
+    border-radius: 4px;
+    color: var(--ink);
+    word-break: break-word;
+  }
+
+  .prose pre code {
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    white-space: pre;
+    word-break: normal;
+  }
+
+  .prose pre.astro-code,
+  .prose pre.shiki {
+    margin: var(--space-lg) 0;
+    padding: var(--space-md);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-md);
+    background: var(--shiki-light-bg);
+    color: var(--shiki-light);
+    font-family: var(--font-mono);
+    font-size: var(--text-small);
+    line-height: 1.55;
+    overflow-x: auto;
+    tab-size: 2;
+  }
+
+  html[data-theme='dark'] .prose pre.astro-code,
+  html[data-theme='dark'] .prose pre.shiki {
+    background-color: var(--shiki-dark-bg) !important;
+    color: var(--shiki-dark) !important;
+  }
+  html[data-theme='dark'] .prose pre.astro-code span,
+  html[data-theme='dark'] .prose pre.shiki span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html:not([data-theme]) .prose pre.astro-code,
+    html:not([data-theme]) .prose pre.shiki {
+      background-color: var(--shiki-dark-bg) !important;
+      color: var(--shiki-dark) !important;
+    }
+    html:not([data-theme]) .prose pre.astro-code span,
+    html:not([data-theme]) .prose pre.shiki span {
+      color: var(--shiki-dark) !important;
+      background-color: var(--shiki-dark-bg) !important;
+      font-style: var(--shiki-dark-font-style) !important;
+      font-weight: var(--shiki-dark-font-weight) !important;
+      text-decoration: var(--shiki-dark-text-decoration) !important;
+    }
+  }
+
+  .prose img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: var(--space-lg) auto;
+    border-radius: var(--radius-md);
+  }
+
+  .prose table {
+    width: 100%;
+    margin: var(--space-lg) 0;
+    border-collapse: collapse;
+    font-size: var(--text-small);
+  }
+  .prose th,
+  .prose td {
+    text-align: start;
+    padding: 0.5em 0.75em;
+    border-bottom: 1px solid var(--rule);
+  }
+  .prose th {
+    font-family: var(--font-display);
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  .prose hr {
+    border: 0;
+    border-top: 1px solid var(--rule);
+    margin: var(--space-xl) 0;
+  }
+
+  .prose .footnotes {
+    margin-top: var(--space-2xl);
+    padding-top: var(--space-md);
+    border-top: 1px solid var(--rule);
+    font-size: var(--text-small);
+    color: var(--ink-muted);
+  }
+  .prose .footnotes h2 {
+    font-size: var(--text-h3);
+    margin-bottom: var(--space-sm);
+  }
+  .prose .footnotes ol {
+    padding-inline-start: var(--space-md);
+  }
+  .prose .footnotes a {
+    color: var(--accent-ink);
   }
 }


### PR DESCRIPTION
## What

End-to-end craft pass on the article surface (`/[year]/[month]/[...slug]`). Five atomic commits:

1. `chore(deps)` — adds `@fontsource/vollkorn` (400 + 400-italic + 600), upgrades Shiki to dual theme (`github-light` + `github-dark`).
2. `feat(article)` — Vollkorn `.prose` styles in `global.css`: serif body (18px / 1.65), Bricolage display headings, accent-tinted link underlines, inline + Shiki code with dark-mode parity (via `!important` on the `pre`/`span` so inline-style colors get overridden).
3. `style(shortcodes)` — real visual treatment for the 4 MDX shortcodes:
   - **Blockquote**: oversized honey curly-quote as the anchor (no side-stripe per the absolute bans), italic Vollkorn body, mono attribution.
   - **Terminal**: minimal mono block with subtle accent `$` prompt; no macOS chrome.
   - **TweetQuote**: ringed-dot anchor evoking the Sigil, italic serif quote, mono attribution.
   - **GitHubRepo**: inline mono pill with octicon + owner/repo + short commit hash.
4. `feat(article)` — `PostNav` (Next read / Previously / All writing →, same hover grammar as homepage lists) + `Comments` (lazy-mounted utteranc.es via IntersectionObserver, theme-synced via postMessage).
5. `feat(article)` — post template rewrite: mono meta line above Bricolage display title + Vollkorn-italic lede; `.prose` body; PostNav + Comments at the bottom. Reveal on header only (no per-paragraph stagger).

## Why

Critique v2 left the article surface as scaffold-grade. Shape pass (above this PR in conversation) confirmed: Vollkorn for body, single-family Bricolage for display (brand-bifurcation on contrast axis), dual-theme Shiki, next-prev chronological post-end, utteranc.es kept and lazy-loaded.

## Test plan

Verified on the 5-post corpus the shape brief named:
- `2026-02-a-gsd-system-for-claude-code` (baseline, no shortcodes)
- `2015-09-dyld-library-not-loaded` (multiple `<Terminal>`)
- `2015-06-hidden-error-variable` (multiple `<TweetQuote>`)
- `2016-06-xcode-8-source-editor-extensions` (`<GitHubRepo>` + `<Terminal>`)
- `2016-01-debugging-autolayout` (`<Blockquote>`)

Each × 2 themes × 2 viewports (1440 + 375) = 20 screenshots at `.claude-visual/article-*.png`. All checked.

- [x] `bun run build` green (26 pages)
- [x] `bun run format:check` green
- [x] Shiki dual theme verified empirically — code blocks track `data-theme`
- [x] All 4 shortcodes render with real visual treatment
- [x] PostNav next/prev chronological logic correct (newest = first, has only `previous`; oldest = last, has only `next`)
- [x] Comments don't block first paint (IntersectionObserver, rootMargin 300px)
- [x] Comments tested live (utteranc.es loads against real GitHub issues — only fires in a real browser visit)
- [ ] `prefers-reduced-motion` audit on the header reveal — manual verify