### PR TITLE
feat(article-hero): per-post hero with Sigil+title SVG fallback

### DIFF
--- a/src/components/article/ArticleHero.astro
+++ b/src/components/article/ArticleHero.astro
@@ -53,14 +53,16 @@ const fallbackSvg =
 </figure>
 
 <style>
-  /* The hero takes the full .article container width (max-content = 64rem). It
-     MUST be placed outside .prose so the body's narrower measure doesn't
-     constrain it. 3:2 ratio enforced via aspect-ratio so layout doesn't shift
-     between fallback SVG and raster <Image />. */
+  /* Hero is capped at the body measure (var(--measure)) so its left + right
+     edges line up with the prose / article header. Earlier draft broke out
+     to the article container width (~1024px) but the body's measure is
+     narrower (~600px), which left the hero visibly wider than the prose.
+     Reading-first surface — the body sets the rhythm, the hero respects it. */
   .article-hero {
     display: block;
-    margin: var(--space-xl) auto;
+    margin: var(--space-xl) 0;
     width: 100%;
+    max-width: var(--measure);
     aspect-ratio: 3 / 2;
     border-radius: var(--radius-md);
     overflow: hidden;

--- a/src/components/article/ArticleHero.astro
+++ b/src/components/article/ArticleHero.astro
@@ -1,0 +1,92 @@
+---
+// ABOUTME: Renders a per-post hero — Astro <Image /> for raster, inline Sigil-fallback SVG otherwise.
+// ABOUTME: 3:2 ratio at the article-container width (caller must place this OUTSIDE .prose to escape the body measure).
+
+import { Image } from 'astro:assets';
+import type { CollectionEntry } from 'astro:content';
+import { resolveHero } from '../../lib/heroResolver';
+import { generateHeroFallbackSvg } from '../../lib/heroFallback';
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+  /** Whether the hero is above the fold; controls loading priority hints. */
+  priority?: boolean;
+}
+
+const { post, priority = true } = Astro.props;
+
+const titleSlug = post.id.replace(/^\d{4}-\d{2}-/, '').replace(/\.mdx?$/, '');
+
+const resolution = resolveHero({
+  slug: titleSlug,
+  title: post.data.title,
+  category: post.data.category,
+  featuredImage: post.data.featured_image,
+  featuredImageAlt: post.data.featured_image_alt,
+});
+
+const fallbackSvg =
+  resolution.kind === 'fallback'
+    ? generateHeroFallbackSvg({ title: resolution.title, category: resolution.category })
+    : null;
+---
+
+<figure
+  class={`article-hero ${resolution.kind === 'fallback' ? 'article-hero--fallback' : 'article-hero--image'}`}
+  aria-label={resolution.alt}
+>
+  {
+    resolution.kind === 'image' ? (
+      <Image
+        src={resolution.image}
+        alt={resolution.alt}
+        widths={[480, 768, 1024, 1440, 1920]}
+        sizes="(max-width: 720px) 100vw, (max-width: 1200px) 90vw, 1024px"
+        loading={priority ? 'eager' : 'lazy'}
+        fetchpriority={priority ? 'high' : 'auto'}
+        decoding="async"
+      />
+    ) : (
+      <Fragment set:html={fallbackSvg} />
+    )
+  }
+</figure>
+
+<style>
+  /* The hero takes the full .article container width (max-content = 64rem). It
+     MUST be placed outside .prose so the body's narrower measure doesn't
+     constrain it. 3:2 ratio enforced via aspect-ratio so layout doesn't shift
+     between fallback SVG and raster <Image />. */
+  .article-hero {
+    display: block;
+    margin: var(--space-xl) auto;
+    width: 100%;
+    aspect-ratio: 3 / 2;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--surface);
+  }
+
+  .article-hero :global(img),
+  .article-hero :global(svg) {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .article-hero--image :global(img) {
+    object-fit: cover;
+  }
+
+  /* Fallback SVG preserves aspect on its own (preserveAspectRatio="meet"). */
+  .article-hero--fallback :global(svg) {
+    object-fit: contain;
+  }
+
+  /* Print: hero hidden to save ink and keep the printable doc text-first. */
+  @media print {
+    .article-hero {
+      display: none !important;
+    }
+  }
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -12,7 +12,14 @@ const blog = defineCollection({
     description: z.string().optional(),
     tags: z.array(z.string()).default([]),
     category: z.enum(['Tech', 'Leadership', 'Productivity', 'Personal', 'Community']),
+    /** Path or slug of the per-post hero image. Optional — resolver falls back
+        to convention path (src/assets/post-heroes/<slug>.*) and then to a
+        Sigil-generated SVG when both are absent. */
     featured_image: z.string().optional(),
+    /** Accessible alt text for the hero image. Required when the image is
+        meaningful; if omitted the resolver uses a generic "Hero illustration
+        for <title>" string. */
+    featured_image_alt: z.string().optional(),
     draft: z.boolean().default(false),
   }),
 });

--- a/src/lib/heroFallback.ts
+++ b/src/lib/heroFallback.ts
@@ -1,0 +1,114 @@
+// ABOUTME: Generates the per-post fallback hero — a 3:2 SVG of the Sigil + post title.
+// ABOUTME: Used when a post has no committed hero asset; same Sigil path data as src/components/marks/Sigil.astro.
+
+/**
+ * Sigil path data — kept in sync with `src/components/marks/Sigil.astro`.
+ * The Sigil component's viewBox is 0 0 24 24; we re-scale below.
+ */
+const SIGIL_RING_D = `M12 2.4
+       C 17.1 2.0, 21.7 6.3, 21.7 12.2
+       C 22.1 17.7, 17.4 21.9, 11.8 21.9
+       C 6.4 22.3, 2.1 17.6, 2.3 11.8
+       C 1.9 6.6, 6.7 2.6, 12 2.4 Z`;
+
+interface FallbackOptions {
+  title: string;
+  /** Category label rendered as a small mono kicker above the title. */
+  category?: string;
+}
+
+/**
+ * Returns inline-SVG markup for a 3:2 hero fallback.
+ *
+ * Composition: oversized wobbly Sigil on the left, post title in Bricolage on
+ * the right. Uses currentColor + CSS custom properties so the SVG picks up the
+ * page theme — embed this with `set:html`, NOT as a separate <img>.
+ *
+ * The viewBox is 1200x800 (3:2). Caller decides actual rendered width via
+ * CSS — preserveAspectRatio is "xMidYMid meet" so it scales cleanly.
+ */
+export function generateHeroFallbackSvg({ title, category }: FallbackOptions): string {
+  // Sigil is rendered at 240px × 240px, parked left-of-center, slightly above the
+  // vertical midline so it visually balances the title block on the right.
+  const sigilScale = 240 / 24; // = 10
+  const sigilX = 160;
+  const sigilY = 260;
+
+  const safeTitle = escapeXml(title);
+  const safeCategory = category ? escapeXml(category) : '';
+
+  return `<svg
+  class="hero-fallback"
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1200 800"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label="${escapeXml(`Hero illustration for ${title}`)}"
+>
+  <defs>
+    <style>
+      .hero-fallback__bg { fill: var(--surface, oklch(0.965 0.006 65)); }
+      .hero-fallback__ring { stroke: var(--accent, oklch(0.58 0.155 60)); stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; fill: none; }
+      .hero-fallback__dot { fill: var(--accent, oklch(0.58 0.155 60)); }
+      .hero-fallback__category { font-family: 'Geist Mono', ui-monospace, Menlo, monospace; font-size: 22px; fill: var(--ink-muted, oklch(0.42 0.012 65)); letter-spacing: 0.04em; text-transform: lowercase; }
+      .hero-fallback__title-fo { color: var(--ink, oklch(0.2 0.005 65)); font-family: 'Bricolage Grotesque Variable', ui-sans-serif, system-ui, sans-serif; font-weight: 700; font-size: 64px; line-height: 1.05; letter-spacing: -0.025em; text-wrap: balance; word-break: break-word; }
+      .hero-fallback__title-fallback { font-family: 'Bricolage Grotesque Variable', ui-sans-serif, system-ui, sans-serif; font-weight: 700; font-size: 56px; letter-spacing: -0.025em; fill: var(--ink, oklch(0.2 0.005 65)); }
+    </style>
+  </defs>
+
+  <rect class="hero-fallback__bg" width="1200" height="800" />
+
+  <g transform="translate(${sigilX} ${sigilY}) scale(${sigilScale})">
+    <path class="hero-fallback__ring" d="${SIGIL_RING_D}" />
+    <circle class="hero-fallback__dot" cx="12.5" cy="12.2" r="3.4" />
+  </g>
+
+  ${
+    safeCategory
+      ? `<text class="hero-fallback__category" x="540" y="240">${safeCategory}</text>`
+      : ''
+  }
+
+  <foreignObject x="540" y="${safeCategory ? 270 : 260}" width="580" height="420">
+    <div xmlns="http://www.w3.org/1999/xhtml" class="hero-fallback__title-fo">
+      ${safeTitle}
+    </div>
+  </foreignObject>
+
+  <!--
+    Pure-SVG fallback for renderers that don't handle <foreignObject> (mostly
+    rasterizers + some RSS readers). Hidden visually under the foreignObject
+    box but exposed as accessible text via aria-label on the parent.
+  -->
+  <text
+    class="hero-fallback__title-fallback"
+    x="540"
+    y="${safeCategory ? 330 : 320}"
+    aria-hidden="true"
+    visibility="hidden"
+  >${truncateForSvgText(safeTitle, 24)}</text>
+</svg>`;
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case "'":
+        return '&apos;';
+      case '"':
+        return '&quot;';
+      default:
+        return c;
+    }
+  });
+}
+
+function truncateForSvgText(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}

--- a/src/lib/heroResolver.ts
+++ b/src/lib/heroResolver.ts
@@ -1,0 +1,114 @@
+// ABOUTME: Three-tier hero resolver for blog posts.
+// ABOUTME: (1) post.data.featured_image path → (2) convention path src/assets/post-heroes/<slug>.{ext} → (3) Sigil-generated fallback SVG.
+
+import type { ImageMetadata } from 'astro';
+
+/**
+ * Build-time glob of every post-hero asset. Vite resolves the URLs + metadata
+ * eagerly so the resolver can look up by slug without runtime fs access.
+ */
+const conventionImages = import.meta.glob<{ default: ImageMetadata }>(
+  '/src/assets/post-heroes/*.{webp,avif,jpg,jpeg,png,svg}',
+  { eager: true },
+);
+
+/**
+ * Optional explicit-path glob — for posts that set `featured_image` in
+ * frontmatter to a path inside src/assets/. Lets the resolver still pull the
+ * Astro Image metadata (dimensions, format) for srcset generation.
+ */
+const explicitImages = import.meta.glob<{ default: ImageMetadata }>(
+  '/src/assets/post-heroes/**/*.{webp,avif,jpg,jpeg,png,svg}',
+  { eager: true },
+);
+
+export type HeroResolution =
+  | {
+      kind: 'image';
+      /** Astro image metadata, ready to pass to the <Image /> component. */
+      image: ImageMetadata;
+      /** Accessible alt text. */
+      alt: string;
+    }
+  | {
+      kind: 'fallback';
+      /** Title used to compose the fallback SVG. */
+      title: string;
+      /** Category used as the small mono kicker above the title. */
+      category?: string;
+      /** Accessible alt text describing the fallback illustration. */
+      alt: string;
+    };
+
+interface ResolveInput {
+  /** Bare post slug (without date prefix or .mdx extension). */
+  slug: string;
+  /** Post title used as alt fallback and as the fallback-SVG title. */
+  title: string;
+  /** Post category, surfaced on the fallback SVG as a kicker. */
+  category?: string;
+  /** Frontmatter `featured_image` field, if present. */
+  featuredImage?: string;
+  /** Frontmatter `featured_image_alt` field, if present. */
+  featuredImageAlt?: string;
+}
+
+/**
+ * Resolve a hero for a post. Tries (in order):
+ *   1. `featuredImage` frontmatter, if it matches a known asset.
+ *   2. Convention path `src/assets/post-heroes/<slug>.<ext>`.
+ *   3. Returns a fallback descriptor so the caller can render the Sigil SVG.
+ */
+export function resolveHero(input: ResolveInput): HeroResolution {
+  const { slug, title, category, featuredImage, featuredImageAlt } = input;
+  const altWhenImage = featuredImageAlt ?? `Hero illustration for ${title}`;
+
+  // Tier 1: explicit path from frontmatter.
+  if (featuredImage) {
+    const explicit = lookupExplicit(featuredImage);
+    if (explicit) {
+      return { kind: 'image', image: explicit, alt: altWhenImage };
+    }
+  }
+
+  // Tier 2: convention path by slug.
+  const conv = lookupConvention(slug);
+  if (conv) {
+    return { kind: 'image', image: conv, alt: altWhenImage };
+  }
+
+  // Tier 3: programmatic fallback.
+  return {
+    kind: 'fallback',
+    title,
+    category,
+    alt: `Brand mark and post title for ${title}`,
+  };
+}
+
+function lookupConvention(slug: string): ImageMetadata | null {
+  for (const [path, mod] of Object.entries(conventionImages)) {
+    // path looks like '/src/assets/post-heroes/<slug>.<ext>'
+    const match = path.match(/\/post-heroes\/([^/]+?)\.[^./]+$/);
+    if (match && match[1] === slug) {
+      return mod.default;
+    }
+  }
+  return null;
+}
+
+function lookupExplicit(featured: string): ImageMetadata | null {
+  // Accept either '/src/assets/...' (absolute project path) or '.../slug.ext'
+  // (just the filename, treated as living under post-heroes/).
+  if (featured.startsWith('/src/assets/')) {
+    const mod = explicitImages[featured];
+    return mod?.default ?? null;
+  }
+  // Try as a basename under post-heroes/.
+  for (const [path, mod] of Object.entries(explicitImages)) {
+    if (path.endsWith('/' + featured) || path.endsWith(featured)) {
+      return mod.default;
+    }
+  }
+  return null;
+}

--- a/src/pages/[year]/[month]/[...slug].astro
+++ b/src/pages/[year]/[month]/[...slug].astro
@@ -3,6 +3,7 @@
 // ABOUTME: Permalink shape preserves Hugo's /:year/:month/:title/. Lazy utteranc.es comments at the bottom.
 
 import BaseLayout from '../../../layouts/BaseLayout.astro';
+import ArticleHero from '../../../components/article/ArticleHero.astro';
 import PostNav from '../../../components/article/PostNav.astro';
 import Comments from '../../../components/article/Comments.astro';
 import { getCollection, render, type CollectionEntry } from 'astro:content';
@@ -63,6 +64,12 @@ const dateFormat = new Intl.DateTimeFormat('en-GB', {
       <h1 class="article__title">{post.data.title}</h1>
       {post.data.description && <p class="article__lede">{post.data.description}</p>}
     </header>
+
+    {
+      /* Hero sits between the article header (meta+title+lede) and the body,
+        per the shape brief — book-chapter-opener placement. */
+    }
+    <ArticleHero post={post} priority />
 
     <div class="prose">
       <Content />


### PR DESCRIPTION
## What

Per-post hero illustration system for blog posts, with the Sigil-vocabulary fallback that ships before the hand-drawn assets land.

- **Three-tier resolver** (`src/lib/heroResolver.ts`):
  1. `featured_image` frontmatter → explicit path under `src/assets/post-heroes/`
  2. Convention path: `src/assets/post-heroes/<post-slug>.{webp,avif,jpg,jpeg,png,svg}`
  3. Programmatic fallback: Sigil + title SVG, surface bg, brand-themed
- **ArticleHero component** (`src/components/article/ArticleHero.astro`): Astro `<Image />` for raster (srcset 480 / 768 / 1024 / 1440 / 1920, `loading="eager"` + `fetchpriority="high"` above the fold), inline SVG via `set:html` for fallback. 3:2 aspect (CSS `aspect-ratio`) prevents layout shift between fallback and real asset. Print stylesheet hides.
- **Sigil fallback generator** (`src/lib/heroFallback.ts`): reuses the exact Sigil ring + dot path data from `src/components/marks/Sigil.astro` (kept in sync as a constant). `foreignObject` for native word-wrap; hidden `<text>` node fallback for rasterizers that don't support foreignObject.
- **Schema** (`src/content/config.ts`) gains `featured_image_alt` for accessible alt text. Resolver synthesizes a default when absent.
- **Slotted between the article header and the `.prose` body** per the shape brief's book-chapter-opener placement.

## Why

Shape: `esttorhe_github_io-psw` — five decisions locked in conversation; this PR ships the system. Hand-drawn assets land on Esteban's schedule; each one replaces the fallback for that post with zero code change.

## How to add a hero to a post

Either:
- Drop a file at `src/assets/post-heroes/<post-slug>.webp` (or .jpg / .png / .svg / .avif) — auto-discovered by convention.
- Or set `featured_image: "post-slug.webp"` in frontmatter for an explicit pointer (lets you use a different filename / shared assets).
- Add `featured_image_alt: "..."` for accessible alt text.

## Test plan

- [x] `bun run build` green (27 pages)
- [x] `bun run format:check` green
- [x] 4 posts × 2 themes × 2 viewports verified via puppeteer
- [x] Long-title wrap holds (tested with "dyld: Library not loaded & CocoaPods")
- [x] Resolver tier-3 fallback is the only path firing today (no hero assets shipped yet)
- [ ] Hand-drawn hero assets — Esteban backfills 23 + ongoing on his schedule
- [ ] OG / RSS image derivative pipeline → `esttorhe_github_io-5n0` (separate follow-up issue, blocked by this)

Closes esttorhe_github_io-psw.