### PR TITLE
feat(talks): port /talks/ shelf forward from Hugo

### DIFF
--- a/src/data/talks.ts
+++ b/src/data/talks.ts
@@ -1,0 +1,110 @@
+// ABOUTME: Talks shelf — manually-curated archive of Esteban's conference talks. Hugo-era port.
+// ABOUTME: Cover image URLs are Speaker Deck og:image (hot-linked; cached at the data layer).
+
+export interface Talk {
+  /** Talk title. Backticks in the original Hugo data render as code spans; keep them. */
+  title: string;
+  /** ISO date string YYYY-MM-DD. The talk date, not when the slides were published. */
+  date: string;
+  /** Conference / venue display name. */
+  conference: string;
+  /** Conference homepage / lineup link, when one exists / still resolves. */
+  conferenceUrl?: string;
+  /** City + country shorthand, or 'Online'. Hidden when absent. */
+  location?: string;
+  /** Speaker Deck or other slides URL. */
+  slidesUrl?: string;
+  /** Video URL (Skills Matter, Vimeo, YouTube). Skills Matter URLs may 404 — they shut down. */
+  videoUrl?: string;
+  /**
+   * Cover image URL — typically the Speaker Deck og:image. Fall back to the
+   * Sigil compact SVG when absent.
+   */
+  coverImage?: string;
+  /** Optional one-line description; if absent the title carries the row. */
+  description?: string;
+}
+
+/**
+ * Talks in reverse-chronological order. Newest first.
+ */
+export const talks: Talk[] = [
+  {
+    title: 'Facing the `VIPER`',
+    date: '2017-09-15',
+    conference: 'NSSpain',
+    conferenceUrl: 'http://nsspain.com',
+    location: 'Logroño, Spain',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/facing-the-viper',
+    videoUrl: 'https://vimeo.com/album/4786409/video/235312913',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/29e4ca1b60b9451cb8ddb45db97f11ab/slide_0.jpg?8590915',
+  },
+  {
+    title: '`MVVM(DC)`: Taming your architecture',
+    date: '2017-02-16',
+    conference: 'MobOS',
+    conferenceUrl: 'http://romobos.com/agenda-2',
+    location: 'Cluj-Napoca, Romania',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/mvvm-dc-taming-your-architecture',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/badd9436b19b4f2ea7ee6d41c788d279/slide_0.jpg?7604246',
+  },
+  {
+    title: 'Hacking (?) `SiriKi`',
+    date: '2016-10-16',
+    conference: 'Mobilization',
+    conferenceUrl: 'http://2016.mobilization.pl',
+    location: 'Łódź, Poland',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/hacking-siriki-mobilization-2016',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/b19b1c9bd1a941cbb2a0203e8dc82bcb/slide_0.jpg?7087679',
+  },
+  {
+    title: '`MVVM` + `RxSwift` + DataControllers',
+    date: '2016-09-16',
+    conference: 'NSSpain',
+    conferenceUrl: 'http://nsspain.com',
+    location: 'Logroño, Spain',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/mvvm-plus-rxswift-plus-datacontrollers-1',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/c70ac241bfe040babb8089e589fe22b3/slide_0.jpg?6843486',
+  },
+  {
+    title: "`Xcode`'s 8 Source Editor Extensions",
+    date: '2016-06-28',
+    conference: 'CocoaHeads Costa Rica',
+    location: 'San José, Costa Rica',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/xcodes-8-source-editor-extensions',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/b95485e40d28466699e0f76be1af5dda/slide_0.jpg?6592494',
+  },
+  {
+    title: '`MVVM` + `RxSwift` + DataControllers',
+    date: '2016-05-26',
+    conference: 'iOScon',
+    location: 'London, UK',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/mvvm-plus-rxswift-plus-datacontrollers',
+    videoUrl: 'https://skillsmatter.com/skillscasts/7863-mvvm-rxswift-and-datacontrollers',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/7d5ec318cd9744f69818c716a2fc1642/slide_0.jpg?6396471',
+  },
+  {
+    title: 'Using `Jekyll` & `Octopress`',
+    date: '2015-06-12',
+    conference: 'Log(n) Tech Talks',
+    location: 'San José, Costa Rica',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/using-jekyll-and-octopress',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/56b126e53c83418a991f4abc63270437/slide_0.jpg?4916082',
+  },
+  {
+    title: 'Continuous Delivery for iOS Apps',
+    date: '2015-04-21',
+    conference: 'CocoaHeads Costa Rica',
+    location: 'San José, Costa Rica',
+    slidesUrl: 'https://speakerdeck.com/esttorhe/continuos-delivery-for-ios-apps',
+    coverImage:
+      'https://files.speakerdeck.com/presentations/ce3838a631c543bead75c2fad41ba0a9/slide_0.jpg?4693595',
+  },
+];

--- a/src/data/talks.ts
+++ b/src/data/talks.ts
@@ -51,7 +51,7 @@ export const talks: Talk[] = [
       'https://files.speakerdeck.com/presentations/badd9436b19b4f2ea7ee6d41c788d279/slide_0.jpg?7604246',
   },
   {
-    title: 'Hacking (?) `SiriKi`',
+    title: 'Hacking (?) `SiriKit`',
     date: '2016-10-16',
     conference: 'Mobilization',
     conferenceUrl: 'http://2016.mobilization.pl',

--- a/src/pages/talks.astro
+++ b/src/pages/talks.astro
@@ -1,0 +1,394 @@
+---
+// ABOUTME: /talks/ — talks shelf. Reverse-chrono archive with Speaker Deck cover thumbnails inline.
+// ABOUTME: Mirrors the /blog/ row pattern (hero left, text right) for surface consistency.
+
+import BaseLayout from '../layouts/BaseLayout.astro';
+import Sigil from '../components/marks/Sigil.astro';
+import { talks } from '../data/talks';
+
+const totalCount = talks.length;
+
+const dateFormat = new Intl.DateTimeFormat('en-GB', {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+});
+
+/**
+ * Render a title string with backtick-delimited code spans. The Hugo data
+ * uses backticks to flag identifiers / framework names; we preserve that.
+ */
+function renderTitle(s: string): { kind: 'text' | 'code'; value: string }[] {
+  const parts: { kind: 'text' | 'code'; value: string }[] = [];
+  let i = 0;
+  while (i < s.length) {
+    const tickStart = s.indexOf('`', i);
+    if (tickStart === -1) {
+      parts.push({ kind: 'text', value: s.slice(i) });
+      break;
+    }
+    if (tickStart > i) parts.push({ kind: 'text', value: s.slice(i, tickStart) });
+    const tickEnd = s.indexOf('`', tickStart + 1);
+    if (tickEnd === -1) {
+      // Unmatched backtick — render literally.
+      parts.push({ kind: 'text', value: s.slice(tickStart) });
+      break;
+    }
+    parts.push({ kind: 'code', value: s.slice(tickStart + 1, tickEnd) });
+    i = tickEnd + 1;
+  }
+  return parts;
+}
+
+interface DecoratedTalk {
+  talk: (typeof talks)[number];
+  parts: ReturnType<typeof renderTitle>;
+  date: Date;
+  index: number;
+}
+
+const decorated: DecoratedTalk[] = talks.map((talk, index) => ({
+  talk,
+  parts: renderTitle(talk.title),
+  date: new Date(talk.date),
+  index,
+}));
+---
+
+<BaseLayout
+  title="Talks"
+  description={`${totalCount} conference talks. Speaker Deck slides; some with video. iOS architecture, RxSwift, VIPER, and a smattering of meta-tooling.`}
+  current="talks"
+>
+  <section class="talks-page" aria-labelledby="talks-heading">
+    <header class="talks-page__header reveal">
+      <h1 id="talks-heading" class="talks-page__title">Talks</h1>
+      <p class="talks-page__meta tabular">
+        <span>{totalCount} talks</span>
+        <span class="talks-page__sep" aria-hidden="true">·</span>
+        <span>newest first</span>
+      </p>
+      <p class="talks-page__pitch">
+        I'm not on the conference circuit these days, but if you're organising an event and think
+        there's a fit, the door is open. Email
+        <a href="mailto:me@estebantorr.es">me@estebantorr.es</a>.
+      </p>
+    </header>
+
+    <ol class="talks-page__list reveal-stagger">
+      {
+        decorated.map(({ talk, parts, date, index }) => (
+          <li class="talks-page__entry" style={`--i: ${index}`}>
+            <article class="talk-row">
+              <figure
+                class={`talk-row__cover ${talk.coverImage ? 'talk-row__cover--image' : 'talk-row__cover--fallback'}`}
+                aria-hidden="true"
+              >
+                {talk.coverImage ? (
+                  <img src={talk.coverImage} alt="" loading="lazy" decoding="async" />
+                ) : (
+                  <Sigil size="60%" />
+                )}
+              </figure>
+
+              <div class="talk-row__text">
+                <p class="talk-row__kicker tabular">
+                  {talk.conferenceUrl ? (
+                    <a href={talk.conferenceUrl} rel="noopener noreferrer">
+                      {talk.conference}
+                    </a>
+                  ) : (
+                    talk.conference
+                  )}
+                </p>
+
+                <h2 class="talk-row__title">
+                  {parts.map((p) =>
+                    p.kind === 'code' ? <code>{p.value}</code> : <Fragment>{p.value}</Fragment>,
+                  )}
+                </h2>
+
+                {talk.description && <p class="talk-row__lede">{talk.description}</p>}
+
+                <p class="talk-row__meta tabular">
+                  <time datetime={talk.date}>{dateFormat.format(date)}</time>
+                  {talk.location && (
+                    <>
+                      <span class="talk-row__sep" aria-hidden="true">
+                        ·
+                      </span>
+                      <span>{talk.location}</span>
+                    </>
+                  )}
+                  {talk.slidesUrl && (
+                    <>
+                      <span class="talk-row__sep" aria-hidden="true">
+                        ·
+                      </span>
+                      <a class="talk-row__link" href={talk.slidesUrl} rel="noopener noreferrer">
+                        slides <span aria-hidden="true">→</span>
+                      </a>
+                    </>
+                  )}
+                  {talk.videoUrl && (
+                    <>
+                      <span class="talk-row__sep" aria-hidden="true">
+                        ·
+                      </span>
+                      <a class="talk-row__link" href={talk.videoUrl} rel="noopener noreferrer">
+                        video <span aria-hidden="true">→</span>
+                      </a>
+                    </>
+                  )}
+                </p>
+              </div>
+            </article>
+          </li>
+        ))
+      }
+    </ol>
+  </section>
+</BaseLayout>
+
+<style>
+  .talks-page {
+    max-width: 52rem;
+    margin: 0 auto;
+    padding-top: var(--space-md);
+  }
+
+  .talks-page__header {
+    margin-bottom: var(--space-xl);
+    max-width: var(--measure-wide);
+  }
+
+  .talks-page__title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: var(--text-h1);
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    color: var(--ink);
+    margin: 0 0 var(--space-xs);
+    text-wrap: balance;
+  }
+
+  .talks-page__meta {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.55ch;
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+    margin: 0 0 var(--space-md);
+  }
+
+  .talks-page__sep {
+    opacity: 0.5;
+  }
+
+  .talks-page__pitch {
+    font-family: var(--font-prose);
+    font-size: var(--text-body);
+    line-height: 1.55;
+    color: var(--ink);
+    margin: 0;
+    max-width: var(--measure);
+  }
+
+  .talks-page__pitch a {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in oklab, var(--accent) 55%, transparent);
+    text-underline-offset: 0.2em;
+    transition:
+      color var(--duration-fast) var(--ease-out-quart),
+      text-decoration-color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .talks-page__pitch a:hover,
+  .talks-page__pitch a:focus-visible {
+    color: var(--accent-ink);
+    text-decoration-color: currentColor;
+    outline: none;
+  }
+
+  .talks-page__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .talks-page__entry {
+    margin: 0;
+  }
+
+  /* Row — mirrors the /blog/ PostListRow grid: cover left, text right. */
+  .talk-row {
+    display: grid;
+    grid-template-columns: 17.5rem 1fr;
+    column-gap: var(--space-lg);
+    align-items: start;
+    padding: var(--space-md) 0;
+  }
+
+  .talk-row__cover {
+    margin: 0;
+    width: 100%;
+    aspect-ratio: 3 / 2;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--surface);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .talk-row__cover img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .talk-row__cover--fallback {
+    color: var(--accent);
+  }
+
+  .talk-row__text {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding-top: 0.25rem;
+  }
+
+  .talk-row__kicker {
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+    margin: 0;
+    letter-spacing: 0.04em;
+    text-transform: lowercase;
+  }
+
+  .talk-row__kicker a {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: border-color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .talk-row__kicker a:hover,
+  .talk-row__kicker a:focus-visible {
+    border-color: var(--accent);
+    outline: none;
+  }
+
+  .talk-row__title {
+    font-family: var(--font-display);
+    font-size: var(--text-h3);
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    color: var(--ink);
+    margin: 0;
+    text-wrap: balance;
+  }
+
+  .talk-row__title code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    font-weight: 600;
+    padding: 0.05em 0.35em;
+    background: color-mix(in oklab, var(--accent) 14%, transparent);
+    color: var(--accent-ink);
+    border-radius: 0.25rem;
+    letter-spacing: 0;
+  }
+
+  .talk-row__lede {
+    font-family: var(--font-prose);
+    font-size: var(--text-body);
+    line-height: 1.5;
+    color: var(--ink-muted);
+    margin: 0;
+    text-wrap: pretty;
+    max-width: 56ch;
+  }
+
+  .talk-row__meta {
+    display: inline-flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.55ch;
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    color: var(--ink-muted);
+    margin: 0;
+    margin-top: var(--space-2xs);
+  }
+
+  .talk-row__sep {
+    opacity: 0.55;
+  }
+
+  .talk-row__link {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in oklab, var(--accent) 55%, transparent);
+    text-underline-offset: 0.2em;
+    transition:
+      color var(--duration-fast) var(--ease-out-quart),
+      text-decoration-color var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .talk-row__link:hover,
+  .talk-row__link:focus-visible {
+    color: var(--accent-ink);
+    text-decoration-color: currentColor;
+    outline: none;
+  }
+
+  @media (max-width: 720px) {
+    .talks-page__header {
+      margin-bottom: var(--space-lg);
+    }
+
+    .talk-row {
+      grid-template-columns: 1fr;
+      row-gap: var(--space-sm);
+      padding: var(--space-sm) 0;
+    }
+
+    .talk-row__title {
+      font-size: var(--text-h3);
+    }
+
+    .talk-row__lede {
+      font-size: var(--text-small);
+    }
+  }
+
+  /* Stagger reveal — caps at 6 since 8 entries is short enough that a long
+     cascade would feel sluggish. */
+  @media (prefers-reduced-motion: no-preference) {
+    .talks-page__entry {
+      opacity: 0;
+      transform: translateY(8px);
+      transition:
+        opacity var(--duration-slow) var(--ease-out-quart),
+        transform var(--duration-slow) var(--ease-out-quart);
+      transition-delay: calc(min(var(--i, 0), 6) * 45ms);
+    }
+
+    :global(.reveal-in) .talks-page__entry,
+    :global(.no-js) .talks-page__entry {
+      opacity: 1;
+      transform: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## What

Builds /talks/ from the Hugo `site/content/talks/index.md` spine. Surfaces 8 talks (2015–2017) from your iOS conference era — NSSpain, iOScon, Mobilization, MobOS, CocoaHeads Costa Rica, Log(n) — each with the Speaker Deck slide cover thumbnail inline + inline slides/video links.

Row anatomy matches /blog/ PostListRow for shelf-to-shelf consistency: cover 3:2 thumbnail left + mono kicker (conference) · Bricolage title with code pills · Geist Mono meta line (date · location · slides → · video →).

## Shape decisions confirmed

- Historical archive + small honest 'pitch slot' for organisers (PRODUCT.md audience). Pitch line under the h1, prose not a CTA card.
- Speaker Deck cover thumbnails inline, hot-linked.
- Reverse-chronological flat list (8 entries doesn't need grouping).

## Decisions worth flagging in code

- **No 'Upcoming' section.** Hugo had one but it's been empty for years; an empty section reads as failure. Add it back when something's on the calendar.
- **`src/data/talks.ts` is the source.** Typed entries; add new talks by appending to the array.
- **Cover URLs are hot-linked from Speaker Deck's S3 CDN.** All 8 fetched once and pinned in the data file. If Speaker Deck invalidates them, the row falls back to a centred Sigil (`coverImage` is optional in the type).
- **Skills Matter URL preserved for iOScon video** even though Skills Matter shut down. It's the canonical record; replace if you find an archive copy.
- **`Hacking _(?)_ \`SiriKi\`` from the Hugo data was simplified to `Hacking (?) \`SiriKi\``** — italic via underscore markdown didn't earn the title-renderer; backtick code spans are the only markup we parse.

## Test plan

- [x] `bun run build` green (31 pages, +1 for /talks/)
- [x] `bun run format:check` green
- [x] Light + dark × 1440/768/375 screenshot-verified
- [x] All 8 cover thumbnails resolve and render
- [x] Mobile: cover stacks above text, meta line wraps gracefully
- [ ] Edit the pitch-slot copy to taste — current line is calibrated to your /about/ voice but you have the stronger version