### PR TITLE
feat(analytics): PostHog (EU) snippet, prod-only, key-optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# ABOUTME: Example env file. Copy to .env.local for local production-build testing of PostHog.
+# ABOUTME: Production reads these from the Cloudflare Pages environment variable settings.
+
+# PostHog (EU) project key. PUBLIC_ prefix is the Astro/Vite convention for
+# vars exposed to the client. PostHog public keys are safe to commit OR
+# inject at build time — capture-only, no admin scope.
+# Get yours from https://eu.posthog.com → Project settings → Project API Key.
+PUBLIC_POSTHOG_KEY=phc_yourProjectKeyHere

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,13 @@ const {
 const siteName = 'The mind of Esteban';
 const fullTitle = title ? (bareTitle ? title : `${title} — ${siteName}`) : siteName;
 const canonical = new URL(Astro.url.pathname, Astro.site ?? 'https://estebantorr.es').toString();
+
+// PostHog (EU). Production-only + no-ops when the public key isn't set, so
+// local dev never reports + a missing CF env var fails open instead of breaking
+// the build. Set PUBLIC_POSTHOG_KEY in the Cloudflare Pages env (or .env.local
+// for local production-build testing).
+const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
+const posthogEnabled = import.meta.env.PROD && Boolean(posthogKey);
 ---
 
 <!doctype html>
@@ -72,6 +79,15 @@ const canonical = new URL(Astro.url.pathname, Astro.site ?? 'https://estebantorr
 
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#1c1714" media="(prefers-color-scheme: dark)" />
+
+    {
+      posthogEnabled && (
+        <script
+          is:inline
+          set:html={`!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);posthog.init(${JSON.stringify(posthogKey)},{api_host:'https://eu.i.posthog.com',defaults:'2026-01-30',capture_pageview:'history_change'});`}
+        />
+      )
+    }
 
     <slot name="head" />
   </head>


### PR DESCRIPTION
## What

Adds the standard PostHog (EU) loader to `BaseLayout.astro`, gated on:

- `import.meta.env.PROD` — skip during `astro dev`
- `PUBLIC_POSTHOG_KEY` presence — fail-open when env var is missing

Both gates are build-time. With no key, the `<script>` tag is not emitted at all (zero bytes added to HTML, no PostHog domain in the network tab). With a key, the standard PostHog snippet loads against `eu.i.posthog.com` and PostHog handles pageview capture via `history_change`.

Key lives in the **Cloudflare Pages env vars** — never committed. `.env.example` documents the var name for local production-build testing (`bun run build && bun run preview`).

## Why this shape

- **`set:html` over `define:vars`.** Astro's `define:vars` injects a `const` at the top of the script, which Prettier's parser chokes on (the official PostHog loader uses comma-expression IIFE patterns Prettier doesn't tolerate). `set:html` with `JSON.stringify(posthogKey)` does the same job — substitutes the key at SSG time, escapes it correctly, and leaves Prettier happy.
- **Production-only.** Local dev pageviews would pollute your funnel and trigger false bot signals. The `import.meta.env.PROD` gate is build-time, so the dev server's HTML literally never carries the snippet.
- **Fail-open when key missing.** A missing CF env var doesn't break the build or render a broken init call. The script just isn't emitted.

## Test plan

- [x] `bun run build` (no key) → 0 PostHog references in `dist/`
- [x] `PUBLIC_POSTHOG_KEY=phc_test bun run build` → 9 PostHog references; `posthog.init("phc_test", ...)` rendered
- [x] `bun run format:check` green
- [x] You set `PUBLIC_POSTHOG_KEY` in the Cloudflare Pages project env vars before the first deploy