### PR TITLE
fix(deploy): pin wrangler 4 (assets-only Workers need it)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,4 +63,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Wrangler 4+ is required for assets-only Workers (no `main` field).
+          # The action's default (3.x) errors with "Missing entry-point".
+          wranglerVersion: '4'
           command: deploy


### PR DESCRIPTION
First production deploy after PR #96 errored with `Missing entry-point` ([run](https://github.com/esttorhe/esttorhe.github.io/actions/runs/27768504005/job/82161700632)). The cloudflare/wrangler-action@v3 default is wrangler 3.90, which doesn't recognise the assets-only Worker pattern (no `main` field in wrangler.jsonc).

Pinning the action to wrangler 4 so it understands `assets.directory` on its own.

## Test plan

- [x] Workflow YAML still lints
- [ ] Push to astro-v2 after merge → wrangler 4 picks up the assets-only config → deploy lands at `estebantorres-es.<subdomain>.workers.dev`