### PR TITLE
chore(deploy): drop public/CNAME, add main to workflow triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,4 +63,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Wrangler 4+ is required for assets-only Workers (no `main` field).
+          # The action's default (3.x) errors with "Missing entry-point".
+          wranglerVersion: '4'
           command: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,9 @@ on:
       - 'docs/**'
       - '**/*.md'
   push:
-    branches: [astro-v2]
+    # Transitional during the astro-v2 → main rename. Once main is the
+    # default and a deploy from main has been verified, drop astro-v2.
+    branches: [astro-v2, main]
 
 concurrency:
   group: deploy-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
   push:
     # Transitional during the astro-v2 → main rename. Once main is the
     # default and a deploy from main has been verified, drop astro-v2.
-    branches: [astro-v2, main]
+    branches: [main]
 
 concurrency:
   group: deploy-${{ github.event.pull_request.number || github.ref }}

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,0 @@
-estebantorr.es


### PR DESCRIPTION
Two coordinated changes ahead of the `astro-v2` → `main` rename.

- `public/CNAME` removed. CF Workers owns the custom-domain mapping (set in the CF dashboard); the GH Pages CNAME file is dead weight on Workers and would only matter if we needed to revert. Astro's static build no longer copies it into `dist/`.
- Workflow trigger transitionally fires on push to **both** `astro-v2` and `main`. This PR's merge still triggers the current deploy. After the rename, pushes to `main` also fire — no intermediate PR needed for the trigger swap.

Once you've renamed `astro-v2` → `main`, set `main` as the default branch, and verified a deploy from `main`, I'll drop `astro-v2` from the trigger in a follow-up.

Part of cutover bd `esttorhe_github_io-x9d`.