### PR TITLE
Draft: Why Engineering Managers Shouldn't Be Translation Layers

### DIFF
--- a/src/content/blog/2026-06-em-translation-layer.mdx
+++ b/src/content/blog/2026-06-em-translation-layer.mdx
@@ -1,0 +1,23 @@
+---
+title: "Why Engineering Managers Shouldn't Be Translation Layers"
+date: 2026-06-19T12:00:00Z
+tags:
+  - org-design
+  - leadership
+  - scaling
+category: Leadership
+description: 'The danger of scaling an engineering org by turning managers into human APIs between product and development.'
+featured_image_alt: 'A conceptual illustration of Why Engineering Managers Shouldn t Be Translation Layers.'
+---
+
+## The Scaling Trap
+- As orgs scale, EMs become human APIs between product and dev.
+- This kills speed, directness, and product intuition.
+
+## The Alternative
+- Protect direct communication between product, design, and engineers (e.g., Peak example).
+- Engineers must own the "why".
+
+## Key Takeaways to expand on
+- Enable push-back culture.
+- Management is for coordination and escalation, not insulating devs from the business.


### PR DESCRIPTION
Drafting the translation layer problem as orgs scale. Will expand on the Backstage and other companies examples.